### PR TITLE
Transition the primary when all its partitions have been stored/recovered

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
+- #8 Make primary sample to follow partitions on store/recover
+
 
 1.0.0 (2019-04-01)
 ------------------


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

If all partitions from a given sample are stored, the primary sample is transitioned to "stored" status automatically too. Partitions in status "rejected", "cancelled" and "invalid" are not considered.

If all partitions from a given sample have been recovered, the primary sample is automatically transitioned to its previous status (before it was transitioned to "stored").

## Current behavior before PR

Primary samples don't follow their partitions regarding to storage.

## Desired behavior after PR is merged

Primary samples follow their partitions regarding to storage.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
