### PR TITLE
Allow samples to be scanned when storing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,3 +11,9 @@ Changelog
 ------------------
 
 - First version of `senaite.storage`
+
+
+1.0.0 (2019-10-31)
+------------------
+**Fixed**
+- #10 ALLOW SAMPLES TO BE SCANNED WHEN STORING

--- a/src/senaite/storage/browser/store_container.py
+++ b/src/senaite/storage/browser/store_container.py
@@ -103,6 +103,22 @@ class StoreContainerView(BaseView):
             return False
         return True
 
+    def get_allowed_states(self):
+        # Get the Sample (aka AR) workflow definition
+        portal_wf = api.get_tool("portal_workflow")
+        arwf = portal_wf["bika_ar_workflow"]
+        ar_states = arwf.states
+
+        allowed_states = []
+
+        # Get the states for which transition "store" is possible
+        for state in ar_states:
+
+            if "store" in ar_states._mapping.get(state).transitions:
+                allowed_states.append(state)
+
+        return allowed_states
+
     def __call__(self):
         form = self.request.form
 

--- a/src/senaite/storage/browser/store_container.py
+++ b/src/senaite/storage/browser/store_container.py
@@ -18,6 +18,8 @@
 # Copyright 2019 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import json
+
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _s
@@ -102,6 +104,13 @@ class StoreContainerView(BaseView):
         if self.get_next_uids():
             return False
         return True
+
+    def get_base_query(self):
+        base_query = {
+            "review_state": self.get_allowed_states(),
+             "sort_on": "created"}
+
+        return json.dumps(base_query)
 
     def get_allowed_states(self):
         # Get the Sample (aka AR) workflow definition

--- a/src/senaite/storage/browser/templates/store_container.pt
+++ b/src/senaite/storage/browser/templates/store_container.pt
@@ -64,11 +64,12 @@
                   <input
                     tal:attributes="name string:sample;"
                     type="text"
+                    tal:define="allowed_states view/get_allowed_states"
                     ui_item="getId"
                     autocomplete="false"
                     class="blurrable firstToFocus referencewidget"
                     base_query='{
-                      "review_state": "sample_received",
+                      "review_state": "get_allowed_states",
                       "sort_on": "created"
                     }'
                     search_query='{}'
@@ -79,7 +80,7 @@
                         {"columnName": "getClientSampleID", "align": "left", "label": "CSID", "width": "15"},
                         {"columnName": "getSampleTypeTitle", "align": "left", "label": "Sample Type", "width": "70"},
                         {"columnName": "UID", "hidden": true}],
-                      "search_fields": ["getId"],
+                      "search_fields": ["SearchableText"],
                       "catalog_name": "bika_catalog_analysisrequest_listing",
                       "url": "referencewidget_search",
                       "discard_empty": [],

--- a/src/senaite/storage/browser/templates/store_container.pt
+++ b/src/senaite/storage/browser/templates/store_container.pt
@@ -75,7 +75,7 @@
                         {"columnName": "getClientSampleID", "align": "left", "label": "CSID", "width": "15"},
                         {"columnName": "getSampleTypeTitle", "align": "left", "label": "Sample Type", "width": "70"},
                         {"columnName": "UID", "hidden": true}],
-                      "search_fields": ["SearchableText"],
+                      "search_fields": ["listing_searchable_text"],
                       "catalog_name": "bika_catalog_analysisrequest_listing",
                       "url": "referencewidget_search",
                       "discard_empty": [],

--- a/src/senaite/storage/browser/templates/store_container.pt
+++ b/src/senaite/storage/browser/templates/store_container.pt
@@ -62,16 +62,11 @@
                 <div class="form-group field ArchetypesReferenceWidget">
                   <label i18n:translate="" for="sample">Sample</label>
                   <input
-                    tal:attributes="name string:sample;"
+                    tal:attributes="name string:sample; base_query view/get_base_query"
                     type="text"
-                    tal:define="allowed_states view/get_allowed_states"
                     ui_item="getId"
                     autocomplete="false"
                     class="blurrable firstToFocus referencewidget"
-                    base_query='{
-                      "review_state": "get_allowed_states",
-                      "sort_on": "created"
-                    }'
                     search_query='{}'
                     catalog_name="bika_catalog_analysisrequest_listing"
                     combogrid_options='{


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/bhp-lims/bhp.lims/issues/210

## Current behavior before PR
Cannot search/scan a sample for store it

## Desired behavior after PR is merged
You can  search/scan a sample in order to store it

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
