### PR TITLE
Changed Base Catalog Tool

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
+- #11 Changed Base Catalog Tool
 - #8 Make primary sample to follow partitions on store/recover
 
 

--- a/src/senaite/storage/catalog.py
+++ b/src/senaite/storage/catalog.py
@@ -18,22 +18,22 @@
 # Copyright 2019 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from AccessControl import ClassSecurityInfo
 from App.class_init import InitializeClass
-from bika.lims.catalog.bika_catalog_tool import BikaCatalogTool
+from bika.lims.catalog.base import BaseCatalog
 from senaite.storage.interfaces import ISenaiteStorageCatalog
 from zope.interface import implements
 
 SENAITE_STORAGE_CATALOG = "senaite_storage_catalog"
 
-class SenaiteStorageCatalog(BikaCatalogTool):
+
+class SenaiteStorageCatalog(BaseCatalog):
     implements(ISenaiteStorageCatalog)
-    security = ClassSecurityInfo()
 
     def __init__(self):
-        BikaCatalogTool.__init__(self,
-                                 id=SENAITE_STORAGE_CATALOG,
-                                 title='Senaite storage catalog',
-                                 portal_meta_type='SenaiteStorageCatalog')
+        BaseCatalog.__init__(self,
+                             id=SENAITE_STORAGE_CATALOG,
+                             title="Senaite storage catalog",
+                             portal_meta_type="SenaiteStorageCatalog")
+
 
 InitializeClass(SenaiteStorageCatalog)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

See: https://github.com/senaite/senaite.core/pull/1487

## Current behavior before PR

Base Class: `bika.lims.catalog.bika_catalog_tool.BikaCatalogTool`

## Desired behavior after PR is merged

Base Class: `bika.lims.catalog.base.BaseCatalog`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
