### PR TITLE
Compatibility with core's 1.3.3

### DIFF
--- a/src/senaite/storage/configure.zcml
+++ b/src/senaite/storage/configure.zcml
@@ -21,6 +21,7 @@
   <!-- Package includes -->
   <include package=".browser"/>
   <include package=".monkeys"/>
+  <include package=".upgrade"/>
   <include package=".subscribers"/>
   <include package=".workflow"/>
 

--- a/src/senaite/storage/upgrade/__init__.py
+++ b/src/senaite/storage/upgrade/__init__.py
@@ -2,8 +2,8 @@
 #
 # This file is part of SENAITE.STORAGE.
 #
-# SENAITE.STORAGE is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by the Free
+# SENAITE.STORAGE is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
 # Software Foundation, version 2.
 #
 # This program is distributed in the hope that it will be useful, but WITHOUT
@@ -17,9 +17,3 @@
 #
 # Copyright 2019-2020 by it's authors.
 # Some rights reserved, see README and LICENSE.
-
-try:
-    __import__('pkg_resources').declare_namespace(__name__)
-except ImportError:
-    from pkgutil import extend_path
-    __path__ = extend_path(__path__, __name__)

--- a/src/senaite/storage/upgrade/configure.zcml
+++ b/src/senaite/storage/upgrade/configure.zcml
@@ -1,0 +1,13 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    i18n_domain="senaite.storage">
+
+<genericsetup:upgradeStep
+        title="Upgrade to SENAITE STORAGE 1.0.1"
+        source="1.0.0"
+        destination="1.0.1"
+        handler="senaite.storage.upgrade.v01_00_001.upgrade"
+        profile="senaite.storage:default"/>
+
+</configure>

--- a/src/senaite/storage/upgrade/v01_00_001.py
+++ b/src/senaite/storage/upgrade/v01_00_001.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.STORAGE.
+#
+# SENAITE.STORAGE is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2019-2020 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from senaite.storage import PRODUCT_NAME
+from senaite.storage import logger
+from senaite.storage.setuphandlers import setup_workflows
+
+from bika.lims.upgrade import upgradestep
+from bika.lims.upgrade.utils import UpgradeUtils
+from bika.lims.upgrade.v01_03_003 import update_wf_received_samples
+
+version = '1.0.1'
+
+
+@upgradestep(PRODUCT_NAME, version)
+def upgrade(tool):
+    portal = tool.aq_inner.aq_parent
+    setup = portal.portal_setup
+    ut = UpgradeUtils(portal)
+    ver_from = ut.getInstalledVersion(PRODUCT_NAME)
+
+    if ut.isOlderVersion(PRODUCT_NAME, version):
+        logger.info("Skipping upgrade of {0}: {1} > {2}".format(
+            PRODUCT_NAME, ver_from, version))
+        return True
+
+    logger.info("Upgrading {0}: {1} -> {2}".format(PRODUCT_NAME, ver_from,
+                                                   version))
+
+    # -------- ADD YOUR STUFF BELOW --------
+
+    # Compatibility with "Fix error when creating a partition as analyst user",
+    # that reimports the worklflow tool and do an updateRoleMappings for Samples
+    # that are in "received" status. Since senaite.storage "overrides" the
+    # definition the sample_workflow, there is the need to setup workflow again
+    # https://github.com/senaite/senaite.core/pull/1525
+    setup_workflows(portal)
+    update_wf_received_samples(portal)
+
+    logger.info("{0} upgraded to version {1}".format(PRODUCT_NAME, version))
+    return True

--- a/templates/write_code_headers.py.in
+++ b/templates/write_code_headers.py.in
@@ -15,7 +15,7 @@ TEMPLATE = """# -*- coding: utf-8 -*-
 #
 # This file is part of SENAITE.STORAGE.
 #
-# SENAITE.CORE.LISTING is free software: you can redistribute it and/or modify
+# SENAITE.STORAGE is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by the Free
 # Software Foundation, version 2.
 #


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Requests restores the workflow modifications done by `senaite.storage` on install, but lost when `senaite.core` is upgraded to 1.3.3 because of https://github.com/senaite/senaite.core/pull/1525

## Current behavior before PR

Sample workflow changes are lost after senaite.core 1.3.3 upgrade

## Desired behavior after PR is merged

Sample workflow changes for senaite.core are restored

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
