### PR TITLE
Folderitem get full object from brain received as param obj

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.0.1 (2020-05-11)
+------------------
+- Refactor folderitem for storage listings to get full object from brain param obj
+
+
 1.0.1 (2020-03-07)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,9 @@
 Changelog
 =========
 
-1.0.1 (2020-05-11)
+1.0.2 (unreleased)
 ------------------
-- Refactor folderitem for storage listings to get full object from brain param obj
+- #14 Refactor folderitem for storage listings to get full object from brain param obj
 
 
 1.0.1 (2020-03-07)

--- a/src/senaite/storage/browser/containers.py
+++ b/src/senaite/storage/browser/containers.py
@@ -96,8 +96,10 @@ class ContainersView(StorageListing):
         """Applies new properties to item (StorageContainer) that is currently
         being rendered as a row in the list
         """
-        obj = api.get_object(obj)
         item = super(ContainersView, self).folderitem(obj, item, index)
+
+        # Get the object (the passed-in "obj" is a brain)
+        obj = api.get_object(obj)
 
         # Containers/Positions usage
         # Samples containers cannot have containers inside!

--- a/src/senaite/storage/browser/containers.py
+++ b/src/senaite/storage/browser/containers.py
@@ -96,6 +96,7 @@ class ContainersView(StorageListing):
         """Applies new properties to item (StorageContainer) that is currently
         being rendered as a row in the list
         """
+        obj = api.get_object(obj)
         item = super(ContainersView, self).folderitem(obj, item, index)
 
         # Containers/Positions usage

--- a/src/senaite/storage/browser/samples.py
+++ b/src/senaite/storage/browser/samples.py
@@ -105,10 +105,10 @@ class SamplesListing(BikaListingView):
                     self.portal_url, "/++resource++bika.lims.images/sample.png")
             }
 
-    def folderitems(self, full_objects=False, classic=False):
+    def folderitems(self):
         """We add this function to tell baselisting to use brains instead of
         full objects"""
-        items = BikaListingView.folderitems(self, full_objects, classic)
+        items = BikaListingView.folderitems(self)
         return sorted(items, key=lambda item: item["position"])
 
     def folderitem(self, obj, item, index):

--- a/src/senaite/storage/browser/storagelisting.py
+++ b/src/senaite/storage/browser/storagelisting.py
@@ -79,6 +79,7 @@ class StorageListing(BikaListingView):
         """Applies new properties to item that is currently being rendered as a
         row in the list
         """
+        obj = api.get_object(obj)
         item["replace"]["Title"] = get_link(item["url"], item["Title"])
         item["replace"]["Id"] = get_link(item["url"], api.get_id(obj))
 

--- a/src/senaite/storage/browser/storagerootfolder.py
+++ b/src/senaite/storage/browser/storagerootfolder.py
@@ -81,6 +81,7 @@ class StorageRootFolderContentsView(StorageListing):
         """Applies new properties to item (StorageFacility) that is currently
         being rendered as a row in the list
         """
+        obj = api.get_object(obj)
         item = super(StorageRootFolderContentsView,
                      self).folderitem(obj, item, index)
 

--- a/src/senaite/storage/browser/storagerootfolder.py
+++ b/src/senaite/storage/browser/storagerootfolder.py
@@ -81,10 +81,10 @@ class StorageRootFolderContentsView(StorageListing):
         """Applies new properties to item (StorageFacility) that is currently
         being rendered as a row in the list
         """
-        obj = api.get_object(obj)
         item = super(StorageRootFolderContentsView,
                      self).folderitem(obj, item, index)
 
+        obj = api.get_object(obj)
         item["replace"]["EmailAddress"] = get_email_link(item["EmailAddress"])
         phone = obj.getPhone()
         if phone:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
Error when accessing containers listing after refactoring folderitem function to always receive a brain as param obj
<img width="1183" alt="Screenshot 2020-05-11 at 18 51 43" src="https://user-images.githubusercontent.com/42575114/81588389-b9482500-93b8-11ea-8609-d3d5f207dcd9.png">
Taceback as follows:
<img width="1418" alt="Screenshot 2020-05-11 at 18 53 02" src="https://user-images.githubusercontent.com/42575114/81588533-f7454900-93b8-11ea-992b-2032c714ef48.png">

## Current behavior before PR

## Desired behavior after PR is merged
The error should now be resolved and able to access the storage listing view

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
