### PR TITLE
Compatibility with core#1717

### DIFF
--- a/src/senaite/storage/browser/store_container.py
+++ b/src/senaite/storage/browser/store_container.py
@@ -23,6 +23,7 @@ import json
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _s
+from senaite.core.workflow import SAMPLE_WORKFLOW
 from senaite.storage import logger
 from senaite.storage import senaiteMessageFactory as _
 
@@ -115,7 +116,7 @@ class StoreContainerView(BaseView):
     def get_allowed_states(self):
         # Get the Sample (aka AR) workflow definition
         portal_wf = api.get_tool("portal_workflow")
-        arwf = portal_wf["bika_ar_workflow"]
+        arwf = portal_wf[SAMPLE_WORKFLOW]
         ar_states = arwf.states
 
         allowed_states = []

--- a/src/senaite/storage/setuphandlers.py
+++ b/src/senaite/storage/setuphandlers.py
@@ -26,6 +26,7 @@ from bika.lims.catalog.catalog_utilities import addZCTextIndex
 from plone import api as ploneapi
 from Products.CMFPlone.utils import _createObjectByType
 from Products.DCWorkflow.Guard import Guard
+from senaite.core.workflow import SAMPLE_WORKFLOW
 from senaite.storage import logger
 from senaite.storage import PRODUCT_NAME
 from senaite.storage import PROFILE_ID
@@ -97,7 +98,7 @@ COLUMNS = [
 ]
 
 WORKFLOWS_TO_UPDATE = {
-    "bika_ar_workflow": {
+    SAMPLE_WORKFLOW: {
         "permissions": (),
         "states": {
             "sample_received": {

--- a/src/senaite/storage/workflow/sample/events.py
+++ b/src/senaite/storage/workflow/sample/events.py
@@ -18,6 +18,7 @@
 # Copyright 2019-2020 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from senaite.core.workflow import SAMPLE_WORKFLOW
 from senaite.storage import api as _api
 from senaite.storage import logger
 from zope.lifecycleevent import modified
@@ -57,7 +58,7 @@ def after_recover(sample):
 
     # Transition the sample to the state before it was stored
     previous_state = get_previous_state(sample) or "sample_due"
-    changeWorkflowState(sample, "bika_ar_workflow", previous_state)
+    changeWorkflowState(sample, SAMPLE_WORKFLOW, previous_state)
 
     # Notify the sample has ben modified
     modified(sample)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes senaite.storage compatible with https://github.com/senaite/senaite.core/pull/1717

## Current behavior before PR

senaite.storage relies on "bika_ar_workflow"

## Desired behavior after PR is merged

senaite.storage relies on "senaite_sample_workflow"

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
