### PR TITLE
Remove booked out samples from container

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.1.0 (unreleased)
 ------------------
 
+- #25 Remove booked out samples from container
 - #23 Allow storage container to be booked out
 - #22 Allow to move containers
 - #21 Allow storage contents to be deactivated

--- a/src/senaite/storage/browser/container/book_out_samples.py
+++ b/src/senaite/storage/browser/container/book_out_samples.py
@@ -66,16 +66,9 @@ class BookOutSamplesView(BaseView):
         This might be either a samples container or a sample context
         """
 
-        # when coming from the WF menu inside a sample
-        if IAnalysisRequest.providedBy(self.context):
-            return [self.context]
-
-        # when coming from the WF menu inside a storage sample
-        if IStorageSamplesContainer.providedBy(self.context):
-            return self.context.get_samples()
-
         # fetch objects from request
         objs = self.get_objects_from_request()
+
         samples = []
         for obj in objs:
             # wjen coming from a samples container listing
@@ -85,7 +78,16 @@ class BookOutSamplesView(BaseView):
             if IAnalysisRequest.providedBy(obj):
                 samples.append(obj)
 
-        return list(set(samples))
+        if samples:
+            return list(set(samples))
+
+        # when coming from the WF menu inside a sample
+        if IAnalysisRequest.providedBy(self.context):
+            return [self.context]
+
+        # when coming from the WF menu inside a storage sample
+        if IStorageSamplesContainer.providedBy(self.context):
+            return self.context.get_samples()
 
     def get_title(self, obj):
         """Return the object title as unicode


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the samples from their container after they were booked out.

## Current behavior before PR

Samples stayed in samples container after book out

## Desired behavior after PR is merged

Samples are removed after book out from their samples container

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
