### PR TITLE
Disallow to modify portal content when stored/booked out samples

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.1.0 (unreleased)
 ------------------
 
+- #26 Disallow to modify portal content when stored/booked out samples
 - #23 Allow storage container to be booked out
 - #22 Allow to move containers
 - #21 Allow storage contents to be deactivated

--- a/src/senaite/storage/setuphandlers.py
+++ b/src/senaite/storage/setuphandlers.py
@@ -25,6 +25,7 @@ from bika.lims.catalog.analysisrequest_catalog import \
     CATALOG_ANALYSIS_REQUEST_LISTING
 from bika.lims.catalog.catalog_utilities import addZCTextIndex
 from plone import api as ploneapi
+from Products.CMFCore.permissions import ModifyPortalContent
 from Products.CMFPlone.utils import _createObjectByType
 from Products.DCWorkflow.Guard import Guard
 from senaite.core.workflow import SAMPLE_WORKFLOW
@@ -174,6 +175,7 @@ WORKFLOWS_TO_UPDATE = {
                     permissions.TransitionPreserveSample: (),
                     permissions.TransitionPublishResults: (),
                     permissions.TransitionScheduleSampling: (),
+                    ModifyPortalContent: (),
                 }
             },
             "booked_out": {
@@ -195,6 +197,7 @@ WORKFLOWS_TO_UPDATE = {
                     permissions.TransitionPreserveSample: (),
                     permissions.TransitionPublishResults: (),
                     permissions.TransitionScheduleSampling: (),
+                    ModifyPortalContent: (),
                 }
             }
         },


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the `ModifyPortalContent` for stored/booked out samples

## Current behavior before PR

Stored/booked out samples can be modified

## Desired behavior after PR is merged

Stored/booked out samples can no longer be modified

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
