### PR TITLE
Added upgrade step event subscriber

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.1.0 (unreleased)
 ------------------
 
+- #28 Added upgrade step event subscriber
 - #27 Integrate dispatch workflow from senaite.core
 - #26 Disallow to modify portal content when stored/booked out samples
 - #25 Remove booked out samples from container

--- a/src/senaite/storage/subscribers/configure.zcml
+++ b/src/senaite/storage/subscribers/configure.zcml
@@ -2,6 +2,12 @@
     xmlns="http://namespaces.zope.org/zope"
     i18n_domain="senaite.storage">
 
+  <!-- After upgrade step event handler -->
+  <subscriber
+    for="senaite.core.events.upgrade.IAfterUpgradeStepEvent"
+    handler="senaite.storage.subscribers.upgrade.afterUpgradeStepHandler"
+  />
+
   <!-- Modified a container. Updates capacity and usage to parent -->
   <subscriber
     for="senaite.storage.interfaces.IStorageLayoutContainer

--- a/src/senaite/storage/subscribers/upgrade.py
+++ b/src/senaite/storage/subscribers/upgrade.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+
+from senaite.storage.setuphandlers import post_install
+
+
+def afterUpgradeStepHandler(event):
+    """Event handler that is executed after running an upgrade step of senaite.core
+    """
+    setup = event.context
+    post_install(setup)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds an upgrade step event handler that runs after each upgrade of `senaite.core`

## Current behavior before PR

Storage upgrade had to be run manually after each upgrade of senaite.core

## Desired behavior after PR is merged

Storage upgrade runs automatically after each upgrade of senaite.core

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
