### PR TITLE
Check if senaite.storage is installed before running handler

### DIFF
--- a/src/senaite/storage/subscribers/upgrade.py
+++ b/src/senaite/storage/subscribers/upgrade.py
@@ -1,10 +1,16 @@
 # -*- coding: utf-8 -*-
 
+from senaite.storage import is_installed
+from senaite.storage import logger
 from senaite.storage.setuphandlers import post_install
 
 
 def afterUpgradeStepHandler(event):
     """Event handler that is executed after running an upgrade step of senaite.core
     """
+    if not is_installed():
+        return
+    logger.info("Run senaite.storage.afterUpgradeStepHandler ...")
     setup = event.context
     post_install(setup)
+    logger.info("Run senaite.storage.afterUpgradeStepHandler [DONE]")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This is an complementary PR for https://github.com/senaite/senaite.storage/pull/28

## Current behavior before PR

Upgrade step handler run although senaite.storage is not installed

## Desired behavior after PR is merged

Upgrade step handler only runs when senaite.storage is installed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
