### PR TITLE
Fixed catalogs in page templates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,10 @@
 Changelog
 =========
 
-2.2.0 (unreleased)
+2.1.1 (unreleased)
 ------------------
 
-- no changes yet
+- #32 Fixed catalogs in page templates
 
 
 2.1.0 (2022-01-05)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-version = "2.2.0"
+version = "2.1.1"
 
 setup(
     name="senaite.storage",

--- a/src/senaite/storage/browser/container/templates/store_container.pt
+++ b/src/senaite/storage/browser/container/templates/store_container.pt
@@ -68,7 +68,7 @@
                        class="custom-select blurrable firstToFocus referencewidget"
                        base_query='{"sort_on": "getId", "sort_order": "ascending", "limit": "30"}'
                        search_query='{}'
-                       catalog_name="bika_catalog_analysisrequest_listing"
+                       catalog_name="senaite_catalog_sample"
                        combogrid_options='{"colModel": [
                                               {"columnName": "getId", "align": "left", "label": "Id", "width": "15"},
                                               {"columnName": "getClientSampleID", "align": "left", "label": "CSID", "width": "15"},
@@ -76,7 +76,7 @@
                                               {"columnName": "UID", "hidden": true}
                                           ],
                                           "search_fields": ["listing_searchable_text"],
-                                          "catalog_name": "bika_catalog_analysisrequest_listing",
+                                          "catalog_name": "senaite_catalog_sample",
                                           "url": "referencewidget_search",
                                           "discard_empty": [],
                                           "showOn": true,

--- a/src/senaite/storage/browser/container/templates/store_samples.pt
+++ b/src/senaite/storage/browser/container/templates/store_samples.pt
@@ -95,14 +95,14 @@
                               "limit": "30"
                             }'
                             search_query='{}'
-                            catalog_name="senaite_storage_catalog"
+                            catalog_name="senaite_catalog_storage"
                             combogrid_options='{
                               "colModel": [
                                 {"columnName": "id", "align": "left", "label": "Id", "width": "10"},
                                 {"columnName": "get_full_title", "align": "left", "label": "Container full path", "width": "90"},
                                 {"columnName": "UID", "hidden": true}],
                               "search_fields": ["listing_searchable_text"],
-                              "catalog_name": "senaite_storage_catalog",
+                              "catalog_name": "senaite_catalog_storage",
                               "url": "referencewidget_search",
                               "discard_empty": [],
                               "showOn": true,

--- a/src/senaite/storage/upgrade/configure.zcml
+++ b/src/senaite/storage/upgrade/configure.zcml
@@ -4,10 +4,10 @@
     i18n_domain="senaite.storage">
 
 <genericsetup:upgradeStep
-        title="Upgrade to SENAITE STORAGE 2.2.0"
+        title="Upgrade to SENAITE STORAGE 2.1.1"
         source="2.1.0"
-        destination="2.2.0"
-        handler="senaite.storage.upgrade.v02_02_000.upgrade"
+        destination="2.1.1"
+        handler="senaite.storage.upgrade.v02_01_100.upgrade"
         profile="senaite.storage:default"/>
 
 <genericsetup:upgradeStep

--- a/src/senaite/storage/upgrade/v02_01_100.py
+++ b/src/senaite/storage/upgrade/v02_01_100.py
@@ -23,7 +23,7 @@ from senaite.core.upgrade.utils import UpgradeUtils
 from senaite.storage import PRODUCT_NAME
 from senaite.storage import logger
 
-version = "2.2.0"
+version = "2.1.1"
 
 
 @upgradestep(PRODUCT_NAME, version)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the catalog IDs in the storage templates

## Current behavior before PR

Old catalog identifiers used, which resulted in JS errors when searching for samples/storages

## Desired behavior after PR is merged

New catalog identifiers used

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
