### PR TITLE
Fix non-lab users can access to storage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
-- no changes yet
+- #34 Fix non-lab users can access to storage
 
 
 2.1.1 (2022-01-08)

--- a/src/senaite/storage/profiles/default/metadata.xml
+++ b/src/senaite/storage/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>2.1.0</version>
+  <version>2.2.0</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/senaite/storage/profiles/default/workflows.xml
+++ b/src/senaite/storage/profiles/default/workflows.xml
@@ -3,8 +3,12 @@
   <property name="title" purge="False">
     Workflow definitions for senaite.storage
   </property>
+  <object name="senaite_storage_folder_workflow" meta_type="Workflow"/>
   <object name="senaite_storage_default_workflow" meta_type="Workflow"/>
   <bindings>
+    <type type_id="StorageRootFolder">
+      <bound-workflow workflow_id="senaite_storage_folder_workflow"/>
+    </type>
     <type type_id="StorageContainer">
       <bound-workflow workflow_id="senaite_storage_default_workflow"/>
     </type>
@@ -12,9 +16,6 @@
       <bound-workflow workflow_id="senaite_storage_default_workflow"/>
     </type>
     <type type_id="StoragePosition">
-      <bound-workflow workflow_id="senaite_storage_default_workflow"/>
-    </type>
-    <type type_id="StorageRootFolder">
       <bound-workflow workflow_id="senaite_storage_default_workflow"/>
     </type>
     <type type_id="StorageSamplesContainer">

--- a/src/senaite/storage/profiles/default/workflows/senaite_storage_folder_workflow/definition.xml
+++ b/src/senaite/storage/profiles/default/workflows/senaite_storage_folder_workflow/definition.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0"?>
+<dc-workflow xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+             workflow_id="senaite_storage_folder_workflow"
+             title="Workflow for storage root folder"
+             description="A one-state (active) workflow for storage root folder"
+             state_variable="review_state"
+             initial_state="active"
+             manager_bypass="False"
+             i18n:domain="senaite.storage">
+
+  <!-- PLONE permissions -->
+  <permission>Access contents information</permission>
+  <permission>Delete objects</permission>
+  <permission>List folder contents</permission>
+  <permission>Modify portal content</permission>
+  <permission>View</permission>
+
+  <!-- State: active -->
+  <state state_id="active" title="Active" i18n:attributes="title">
+    <exit-transition transition_id="" />
+    <permission-map name="Access contents information" acquired="False">
+      <!-- All except Anonymous and Client -->
+      <permission-role>Analyst</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Preserver</permission-role>
+      <permission-role>RegulatoryInspector</permission-role>
+      <permission-role>Sampler</permission-role>
+      <permission-role>SamplingCoordinator</permission-role>
+      <!-- Plone roles -->
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="Delete objects" acquired="False" />
+    <permission-map name="List folder contents" acquired="False">
+      <!-- All except Anonymous and Client -->
+      <permission-role>Analyst</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Preserver</permission-role>
+      <permission-role>RegulatoryInspector</permission-role>
+      <permission-role>Sampler</permission-role>
+      <permission-role>SamplingCoordinator</permission-role>
+      <!-- Plone roles -->
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="Modify portal content" acquired="False">
+      <permission-role>LabClerk</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="View" acquired="False">
+      <!-- All except Anonymous and Client -->
+      <permission-role>Analyst</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Preserver</permission-role>
+      <permission-role>RegulatoryInspector</permission-role>
+      <permission-role>Sampler</permission-role>
+      <permission-role>SamplingCoordinator</permission-role>
+      <!-- Plone roles -->
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+  </state>
+
+  <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
+    <description>Previous transition</description>
+    <default>
+      <expression>transition/getId|nothing</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+
+  <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
+    <description>The ID of the user who performed the last transition</description>
+    <default>
+      <expression>user/getId</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+
+  <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
+    <description>Comment about the last transition</description>
+    <default>
+      <expression>python:state_change.kwargs.get('comment', '')</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+
+  <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
+    <description>Provides access to workflow history</description>
+    <default>
+      <expression>state_change/getHistory</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+
+  <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
+    <description>When the previous transition was performed</description>
+    <default>
+      <expression>state_change/getDateTime</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+
+</dc-workflow>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request binds the `StorageRootFolder` type to a new "one-state" workflow so only lab personnel can access to storage and descendents.

Linked issue: https://github.com/senaite/senaite.storage/issues/33

## Current behavior before PR

Clients can access to storage

## Desired behavior after PR is merged

Clients cannot access to storage

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
