### PR TITLE
Add storage settings for auto-store/recover of primary sample

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #39 Add storage settings for auto-store/recover of primary sample
 - #38 Remove Script (Python) for guards in favour of guard_handler
 
 

--- a/src/senaite/storage/__init__.py
+++ b/src/senaite/storage/__init__.py
@@ -33,6 +33,8 @@ from zope.i18nmessageid import MessageFactory
 # Defining a Message Factory for when this product is internationalized.
 senaiteMessageFactory = MessageFactory(PRODUCT_NAME)
 
+_ = senaiteMessageFactory
+
 logger = logging.getLogger(PRODUCT_NAME)
 
 

--- a/src/senaite/storage/browser/configure.zcml
+++ b/src/senaite/storage/browser/configure.zcml
@@ -1,8 +1,7 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser"
-    xmlns:plone="http://namespaces.plone.org/plone"
-    i18n_domain="senaite.storage">
+    xmlns:plone="http://namespaces.plone.org/plone">
 
   <!-- package includes -->
   <include package=".container"/>
@@ -18,5 +17,13 @@
       directory="static"
       type="plone"
       name="senaite.storage.static" />
+
+  <!-- Storage Control panel -->
+  <browser:page
+      name="storage-controlpanel"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      class=".controlpanel.StorageControlPanelView"
+      permission="senaite.core.permissions.ManageBika"
+      layer="senaite.storage.interfaces.ISenaiteStorageLayer"/>
 
 </configure>

--- a/src/senaite/storage/browser/controlpanel.py
+++ b/src/senaite/storage/browser/controlpanel.py
@@ -38,7 +38,7 @@ class IStorageControlPanel(Interface):
         description=_(
             u"description_storage_settings_store_primary",
             default=u"Select this option to automatically transition the "
-                    u"primary sample to 'stored' status when it does not have"
+                    u"primary sample to 'stored' status when it does not have "
                     u"analyses assigned and all its partitions are stored."
         ),
         default=True,

--- a/src/senaite/storage/browser/controlpanel.py
+++ b/src/senaite/storage/browser/controlpanel.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.STORAGE.
+#
+# SENAITE.STORAGE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2019-2024 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from plone.app.registry.browser.controlpanel import ControlPanelFormWrapper
+from plone.app.registry.browser.controlpanel import RegistryEditForm
+from plone.z3cform import layout
+from senaite.storage import _
+from zope import schema
+from zope.interface import Interface
+
+
+class IStorageControlPanel(Interface):
+    """Control panel Settings for senaite.storage
+    """
+
+    store_primary = schema.Bool(
+        title=_(
+            u"label_storage_settings_store_primary",
+            default=u"Auto-store primary sample"
+        ),
+        description=_(
+            u"description_storage_settings_store_primary",
+            default=u"Select this option to automatically transition the "
+                    u"primary sample to 'stored' status when all its "
+                    u"partitions are stored."
+        ),
+    )
+
+    restore_primary = schema.Bool(
+        title=_(
+            u"label_storage_settings_restore_primary",
+            default=u"Auto-restore primary sample"
+        ),
+        description=_(
+            u"description_storage_settings_restore_primary",
+            default=u"Select this option to automatically restore the primary "
+                    u"sample when at least one of its partitions is restored "
+                    u"from storage."
+        ),
+    )
+
+
+class StorageControlPanelForm(RegistryEditForm):
+    schema = IStorageControlPanel
+    schema_prefix = "senaite.storage"
+    label = _(u"header_storage_settings", default=u"Storage Settings")
+
+
+StorageControlPanelView = layout.wrap_form(StorageControlPanelForm,
+                                           ControlPanelFormWrapper)

--- a/src/senaite/storage/browser/controlpanel.py
+++ b/src/senaite/storage/browser/controlpanel.py
@@ -38,8 +38,8 @@ class IStorageControlPanel(Interface):
         description=_(
             u"description_storage_settings_store_primary",
             default=u"Select this option to automatically transition the "
-                    u"primary sample to 'stored' status when all its "
-                    u"partitions are stored."
+                    u"primary sample to 'stored' status when it does not have"
+                    u"analyses assigned and all its partitions are stored."
         ),
         default=True,
     )

--- a/src/senaite/storage/browser/controlpanel.py
+++ b/src/senaite/storage/browser/controlpanel.py
@@ -43,16 +43,16 @@ class IStorageControlPanel(Interface):
         ),
     )
 
-    restore_primary = schema.Bool(
+    recover_primary = schema.Bool(
         title=_(
-            u"label_storage_settings_restore_primary",
-            default=u"Auto-restore primary sample"
+            u"label_storage_settings_recover_primary",
+            default=u"Auto-recover primary sample"
         ),
         description=_(
-            u"description_storage_settings_restore_primary",
-            default=u"Select this option to automatically restore the primary "
-                    u"sample when at least one of its partitions is restored "
-                    u"from storage."
+            u"description_storage_settings_recover_primary",
+            default=u"Select this option to automatically transition back the "
+                    u"primary from 'stored' to its preceding status when all "
+                    u"its partitions are recovered."
         ),
     )
 

--- a/src/senaite/storage/browser/controlpanel.py
+++ b/src/senaite/storage/browser/controlpanel.py
@@ -41,6 +41,7 @@ class IStorageControlPanel(Interface):
                     u"primary sample to 'stored' status when all its "
                     u"partitions are stored."
         ),
+        default=True,
     )
 
     recover_primary = schema.Bool(
@@ -54,6 +55,7 @@ class IStorageControlPanel(Interface):
                     u"primary from 'stored' to its preceding status when all "
                     u"its partitions are recovered."
         ),
+        default=True,
     )
 
 

--- a/src/senaite/storage/profiles/default/controlpanel.xml
+++ b/src/senaite/storage/profiles/default/controlpanel.xml
@@ -1,0 +1,19 @@
+<object
+  name="portal_controlpanel"
+  xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+  <configlet
+    title="Storage settings"
+    action_id="senaite.storage"
+    appId="senaite.storage"
+    category="Products"
+    condition_expr=""
+    icon_expr="senaite_theme/icon/storage"
+    url_expr="string:${portal_url}/@@storage-controlpanel"
+    visible="True"
+    i18n:domain="senaite.storage"
+    i18n:attributes="title">
+    <permission>senaite.core: Manage Bika</permission>
+  </configlet>
+
+</object>

--- a/src/senaite/storage/profiles/default/metadata.xml
+++ b/src/senaite/storage/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>2601</version>
+  <version>2602</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/senaite/storage/profiles/default/registry.xml
+++ b/src/senaite/storage/profiles/default/registry.xml
@@ -1,0 +1,5 @@
+<registry>
+  <records
+      interface="senaite.storage.browser.controlpanel.IStorageControlPanel"
+      prefix="senaite.storage"/>
+</registry>

--- a/src/senaite/storage/profiles/uninstall/controlpanel.xml
+++ b/src/senaite/storage/profiles/uninstall/controlpanel.xml
@@ -1,0 +1,3 @@
+<object name="portal_controlpanel">
+  <configlet action_id="senaite.storage" remove="True"/>
+</object>

--- a/src/senaite/storage/profiles/uninstall/registry.xml
+++ b/src/senaite/storage/profiles/uninstall/registry.xml
@@ -1,0 +1,5 @@
+<registry>
+  <records
+      interface="senaite.storage.browser.controlpanel.IStorageControlPanel"
+      remove="True"/>
+</registry>

--- a/src/senaite/storage/tests/base.py
+++ b/src/senaite/storage/tests/base.py
@@ -38,14 +38,16 @@ class SimpleTestLayer(PloneSandboxLayer):
         super(SimpleTestLayer, self).setUpZope(app, configurationContext)
 
         import bika.lims
-        import senaite.core
         import senaite.app.listing
-        import senaite.impress
         import senaite.app.spotlight
+        import senaite.core
+        import senaite.impress
+        import senaite.lims
         import senaite.storage
 
         # Load ZCML
         self.loadZCML(package=bika.lims)
+        self.loadZCML(package=senaite.lims)
         self.loadZCML(package=senaite.core)
         self.loadZCML(package=senaite.app.listing)
         self.loadZCML(package=senaite.impress)
@@ -54,6 +56,7 @@ class SimpleTestLayer(PloneSandboxLayer):
 
         # Install product and call its initialize() function
         zope.installProduct(app, "bika.lims")
+        zope.installProduct(app, "senaite.lims")
         zope.installProduct(app, "senaite.core")
         zope.installProduct(app, "senaite.app.listing")
         zope.installProduct(app, "senaite.impress")

--- a/src/senaite/storage/tests/doctests/PrimarySample.rst
+++ b/src/senaite/storage/tests/doctests/PrimarySample.rst
@@ -1,0 +1,132 @@
+Primary Sample
+--------------
+
+When using partitions, `senaite.storage` automatically transitions the primary
+samples for them to follow the status of their partitions. This applies for
+both `store` and `recover` transitions. Although this is the behavior set by
+default, user can change it from Storage's control panel, under Site setup.
+
+Test Setup
+..........
+
+Running this test from the buildout directory:
+
+    bin/test -t PrimarySample
+
+Needed Imports:
+
+    >>> from bika.lims import api
+    >>> #from bika.lims.api.security import get_valid_roles_for
+    >>> #from bika.lims.api.security import revoke_permission_for
+    >>> #from bika.lims.permissions import TransitionReceiveSample
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+    >>> from bika.lims.utils.analysisrequest import create_partition
+    >>> from bika.lims.workflow import doActionFor as do_action_for
+    >>> from DateTime import DateTime
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+
+Functional Helpers:
+
+    >>> def new_sample_container(**kwargs):
+    ...     return api.create(sc, "StorageSamplesContainer", **kwargs)
+
+    >>> def new_sample(services):
+    ...     values = {
+    ...         'Client': client.UID(),
+    ...         'Contact': contact.UID(),
+    ...         'DateSampled': DateTime().strftime("%Y-%m-%d"),
+    ...         'SampleType': sampletype.UID()}
+    ...     uids = map(api.get_uid, services)
+    ...     return create_analysisrequest(client, request, values, uids)
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> setup = api.get_setup()
+    >>> storage = portal.senaite_storage
+
+Assign default roles for the user to test with:
+
+    >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
+
+Setup baseline storage objects for the test:
+
+    >>> sf = api.create(storage, "StorageFacility", title="Storage facility")
+    >>> sp = api.create(sf, "StoragePosition", title="Room A")
+    >>> sc = api.create(sp, "StorageContainer", title="Freezer A")
+
+Create some baseline objects for the test:
+
+    >>> client = api.create(portal.clients, "Client", Name="Happy Hills", ClientID="HH", MemberDiscountApplies=True)
+    >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
+    >>> sampletype = api.create(setup.bika_sampletypes, "SampleType", title="Water", Prefix="W")
+    >>> labcontact = api.create(setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(setup.bika_departments, "Department", title="Chemistry", Manager=labcontact)
+    >>> category = api.create(setup.bika_analysiscategories, "AnalysisCategory", title="Metals", Department=department)
+    >>> Cu = api.create(setup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Price="15", Category=category.UID(), Accredited=True)
+    >>> Fe = api.create(setup.bika_analysisservices, "AnalysisService", title="Iron", Keyword="Fe", Price="10", Category=category.UID())
+    >>> Au = api.create(setup.bika_analysisservices, "AnalysisService", title="Gold", Keyword="Au", Price="20", Category=category.UID())
+
+Auto-transition primary sample
+..............................
+
+Create a sample container:
+
+    >>> ssc = new_sample_container(title="3x3", Rows=3, Columns=3)
+
+Create a Sample and two partitions:
+
+    >>> sample = new_sample([Fe, Au])
+    >>> transitioned = do_action_for(sample, "receive")
+    >>> analyses = sample.getAnalyses(full_objects=True)
+    >>> part1 = create_partition(sample, request, [analyses[0]])
+    >>> part2 = create_partition(sample, request, [analyses[1]])
+
+Store the partition 1:
+
+    >>> ssc.add_object_at(part1, 0, 0)
+    True
+    >>> api.get_review_status(part1)
+    'stored'
+
+Both the primary and partition 2 remain in `sample_received` status:
+
+    >>> api.get_review_status(sample)
+    'sample_received'
+    >>> api.get_review_status(part2)
+    'sample_received'
+
+Store the partition 2:
+
+    >>> ssc.add_object_at(part2, 0, 1)
+    True
+    >>> api.get_review_status(part2)
+    'stored'
+
+The primary is automatically transitioned to `stored` status too:
+
+    >>> api.get_review_status(sample)
+    'stored'
+
+Restore the partition 1:
+
+    >>> transitioned = do_action_for(part1, "recover")
+    >>> api.get_review_status(part1)
+    'sample_received'
+    >>> api.get_review_status(part2)
+    'stored'
+    >>> api.get_review_status(sample)
+    'stored'
+
+Restore the partition 2:
+
+    >>> transitioned = do_action_for(part2, "recover")
+    >>> api.get_review_status(part2)
+    'sample_received'
+
+The primary sample is transitioned to `sample_received` as well:
+
+    >>> api.get_review_status(sample)
+    'sample_received'

--- a/src/senaite/storage/tests/doctests/PrimarySample.rst
+++ b/src/senaite/storage/tests/doctests/PrimarySample.rst
@@ -16,13 +16,11 @@ Running this test from the buildout directory:
 Needed Imports:
 
     >>> from bika.lims import api
-    >>> #from bika.lims.api.security import get_valid_roles_for
-    >>> #from bika.lims.api.security import revoke_permission_for
-    >>> #from bika.lims.permissions import TransitionReceiveSample
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
     >>> from bika.lims.utils.analysisrequest import create_partition
     >>> from bika.lims.workflow import doActionFor as do_action_for
     >>> from DateTime import DateTime
+    >>> from plone import api as ploneapi
     >>> from plone.app.testing import setRoles
     >>> from plone.app.testing import TEST_USER_ID
 
@@ -74,9 +72,9 @@ Auto-transition primary sample
 
 Create a sample container:
 
-    >>> ssc = new_sample_container(title="3x3", Rows=3, Columns=3)
+    >>> ssc = new_sample_container(title="Container 1", Rows=3, Columns=3)
 
-Create a Sample and two partitions:
+Create a Sample with two partitions:
 
     >>> sample = new_sample([Fe, Au])
     >>> transitioned = do_action_for(sample, "receive")
@@ -128,5 +126,114 @@ Restore the partition 2:
 
 The primary sample is transitioned to `sample_received` as well:
 
+    >>> api.get_review_status(sample)
+    'sample_received'
+
+
+Primary sample with analyses
+............................
+
+If the primary sample has analyses assigned, the auto-transition cannot take
+place. Create a sample container:
+
+    >>> ssc = new_sample_container(title="Container 2", Rows=3, Columns=3)
+
+Create a Sample with two partitions and three analyses. And keep one of the
+analyses in the primary sample:
+
+    >>> sample = new_sample([Cu, Fe, Au])
+    >>> transitioned = do_action_for(sample, "receive")
+    >>> analyses = sample.getAnalyses(full_objects=True)
+    >>> part1 = create_partition(sample, request, [analyses[0]])
+    >>> part2 = create_partition(sample, request, [analyses[1]])
+
+Store the partition 1:
+
+    >>> ssc.add_object_at(part1, 0, 0)
+    True
+    >>> api.get_review_status(part1)
+    'stored'
+
+Both the primary and partition 2 remain in `sample_received` status:
+
+    >>> api.get_review_status(sample)
+    'sample_received'
+    >>> api.get_review_status(part2)
+    'sample_received'
+
+Store the partition 2:
+
+    >>> ssc.add_object_at(part2, 0, 1)
+    True
+    >>> api.get_review_status(part2)
+    'stored'
+
+The primary remains in `sample_received` status:
+
+    >>> api.get_review_status(sample)
+    'sample_received'
+
+We can manually store the primary sample though:
+
+    >>> ssc.add_object_at(sample, 0, 2)
+    True
+    >>> api.get_review_status(sample)
+    'stored'
+
+
+Shortcut auto-transition
+........................
+
+Shortcut the auto-transitions:
+
+    >>> ploneapi.portal.set_registry_record("senaite.storage.store_primary", False)
+    >>> ploneapi.portal.set_registry_record("senaite.storage.recover_primary", False)
+
+Create a sample container:
+
+    >>> ssc = new_sample_container(title="Container 3", Rows=3, Columns=3)
+
+Create a Sample with two partitions and two analyses:
+
+    >>> sample = new_sample([Fe, Au])
+    >>> transitioned = do_action_for(sample, "receive")
+    >>> analyses = sample.getAnalyses(full_objects=True)
+    >>> part1 = create_partition(sample, request, [analyses[0]])
+    >>> part2 = create_partition(sample, request, [analyses[1]])
+
+Store the partitions:
+
+    >>> ssc.add_object_at(part1, 0, 0)
+    True
+    >>> ssc.add_object_at(part2, 0, 1)
+    True
+
+The primary remains in `sample_received` status:
+
+    >>> api.get_review_status(sample)
+    'sample_received'
+
+We can manually store the primary though:
+
+    >>> ssc.add_object_at(sample, 0, 2)
+    True
+    >>> api.get_review_status(sample)
+    'stored'
+
+If we recover the partitions:
+
+    >>> do_action_for(part1, "recover")
+    (True, '')
+    >>> do_action_for(part2, "recover")
+    (True, '')
+
+The primary remains in `stored` status:
+
+    >>> api.get_review_status(sample)
+    'stored'
+
+We can manually recover the primary:
+
+    >>> success = do_action_for(sample, "recover")
     >>> api.get_review_status(sample)
     'sample_received'

--- a/src/senaite/storage/upgrade/v02_06_000.py
+++ b/src/senaite/storage/upgrade/v02_06_000.py
@@ -70,3 +70,12 @@ def remove_guard_scripts(tool):
         del selections[scripts_id]
     if scripts_id in skins_tool:
         del skins_tool[scripts_id]
+
+
+def setup_storage_controlpanel(tool):
+    """Setup the storage control panel
+    """
+    portal = tool.aq_inner.aq_parent
+    setup = portal.portal_setup
+    setup.runImportStepFromProfile(profile, "plone.app.registry")
+    setup.runImportStepFromProfile(profile, "controlpanel")

--- a/src/senaite/storage/upgrade/v02_06_000.zcml
+++ b/src/senaite/storage/upgrade/v02_06_000.zcml
@@ -3,6 +3,14 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="SENAITE.STORAGE 2.6.0: Setup Storage's control panel"
+      description="Setup Storage's control panel"
+      source="2601"
+      destination="2602"
+      handler=".v02_06_000.setup_storage_controlpanel"
+      profile="senaite.storage:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.STORAGE 2.6.0: Remove Scripts (Python) for guards"
       description="Removes the Scripts (Python) for guards"
       source="2600"

--- a/src/senaite/storage/workflow/sample/events.py
+++ b/src/senaite/storage/workflow/sample/events.py
@@ -24,7 +24,24 @@ from bika.lims.api.snapshot import resume_snapshots_for
 from bika.lims.utils import changeWorkflowState
 from bika.lims.workflow import doActionFor as do_action_for
 from senaite.core.workflow import SAMPLE_WORKFLOW
+from senaite.storage.config import PRODUCT_NAME
 from senaite.storage import api as _api
+
+
+def is_store_primary_enabled():
+    """Returns whether the transition 'store' must be automatically triggered
+    for primary sample when all its partitions have been stored
+    """
+    key = "{}.store_primary".format(PRODUCT_NAME)
+    return api.get_registry_record(key, default=True)
+
+
+def is_recover_primary_enabled():
+    """Returns whether the transition 'recover' must be automatically triggered
+    for primary sample when all its partitions have been recovered
+    """
+    key = "{}.recover_primary".format(PRODUCT_NAME)
+    return api.get_registry_record(key, default=True)
 
 
 def before_dispatch(sample):
@@ -39,6 +56,10 @@ def before_dispatch(sample):
 def after_store(sample):
     """Event triggered after "store" transition takes place for a given sample
     """
+    if not is_store_primary_enabled():
+        return
+
+    # auto-store the primary sample if all its partitions are stored
     primary = sample.getParentAnalysisRequest()
     if not primary:
         return
@@ -70,6 +91,10 @@ def after_recover(sample):
 
     # Reindex the sample
     sample.reindexObject()
+
+    if not is_recover_primary_enabled():
+        # Do not auto-recover the primary, if any
+        return
 
     # If the sample is a partition, try to promote to the primary
     primary = sample.getParentAnalysisRequest()

--- a/src/senaite/storage/workflow/sample/events.py
+++ b/src/senaite/storage/workflow/sample/events.py
@@ -21,6 +21,7 @@
 from bika.lims import api
 from bika.lims.api.snapshot import pause_snapshots_for
 from bika.lims.api.snapshot import resume_snapshots_for
+from bika.lims.interfaces import IAnalysis
 from bika.lims.utils import changeWorkflowState
 from bika.lims.workflow import doActionFor as do_action_for
 from senaite.core.workflow import SAMPLE_WORKFLOW
@@ -62,6 +63,11 @@ def after_store(sample):
     # auto-store the primary sample if all its partitions are stored
     primary = sample.getParentAnalysisRequest()
     if not primary:
+        return
+
+    # Do not store primary if it has it's own analyses assigned
+    analyses = filter(IAnalysis.providedBy, primary.objectValues())
+    if len(analyses) > 0:
         return
 
     # Store primary sample if its partitions have been stored


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds a control panel for `senaite.storage` that allows the user to configure the behavior of the system regarding to the "store" and "recover" transitions against the primary sample when all its partitions have been transitioned.

![Captura de 2024-01-15 13-53-32](https://github.com/senaite/senaite.storage/assets/832627/0dbfb4ca-5e8b-479a-96a4-03ad908467ad)


## Current behavior before PR

System automatically transitions the primary sample (store or recover) when all its partitions have been transitioned

## Desired behavior after PR is merged

User can configure the behavior regarding the auto-store and auto-recover of primary samples

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
