### PR TITLE
Add discard action for stored samples with pre-defined options

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #40 Add discard action for stored samples with pre-defined options
 - #39 Add storage settings for auto-store/recover of primary sample
 - #38 Remove Script (Python) for guards in favour of guard_handler
 

--- a/src/senaite/storage/adapters/listing.py
+++ b/src/senaite/storage/adapters/listing.py
@@ -78,7 +78,7 @@ class AnalysisRequestsListingViewAdapter(object):
             "url": "workflow_action?action=print_stickers"
         }
 
-        # "stored" and "discarded review states
+        # "stored" review state
         stored = {
             "id": "stored",
             "title": _("Stored"),

--- a/src/senaite/storage/adapters/listing.py
+++ b/src/senaite/storage/adapters/listing.py
@@ -78,7 +78,7 @@ class AnalysisRequestsListingViewAdapter(object):
             "url": "workflow_action?action=print_stickers"
         }
 
-        # "stored" review state
+        # "stored" and "discarded review states
         stored = {
             "id": "stored",
             "title": _("Stored"),
@@ -95,6 +95,18 @@ class AnalysisRequestsListingViewAdapter(object):
 
         # Add the review state
         utils.add_review_state(self.listing, stored, after="published")
+
+        discarded = {
+            "id": "discarded",
+            "title": _("Discarded"),
+            "contentFilter": {
+                "review_state": ("discarded",),
+                "sort_on": "created",
+                "sort_order": "descending",
+            },
+            "columns": columns,
+        }
+        utils.add_review_state(self.listing, discarded, after="stored")
 
         # Add the column "DateStored" to "stored" review_state
         column_values = {

--- a/src/senaite/storage/browser/configure.zcml
+++ b/src/senaite/storage/browser/configure.zcml
@@ -7,6 +7,7 @@
   <include package=".container"/>
   <include package=".facility"/>
   <include package=".position"/>
+  <include package=".samples"/>
   <include package=".storage"/>
   <include package=".theme"/>
   <include package=".viewlets"/>

--- a/src/senaite/storage/browser/controlpanel.py
+++ b/src/senaite/storage/browser/controlpanel.py
@@ -58,6 +58,23 @@ class IStorageControlPanel(Interface):
         default=True,
     )
 
+    discard_reasons = schema.List(
+        title=_(
+            u"label_storage_settings_discard_reasons",
+            default=u"Discard reasons"
+        ),
+        description=_(
+            u"description_storage_settings_discard_reasons",
+            default=u"Pre-defined reasons to be displayed for selection when "
+                    u"discarding samples from storage."
+        ),
+        value_type=schema.ASCIILine(),
+        default=[
+            _("Exceeded storage time"),
+        ],
+        required=False,
+    )
+
 
 class StorageControlPanelForm(RegistryEditForm):
     schema = IStorageControlPanel

--- a/src/senaite/storage/browser/samples/configure.zcml
+++ b/src/senaite/storage/browser/samples/configure.zcml
@@ -1,0 +1,13 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser">
+
+  <!-- Discard samples view, with a pre-defined set of reasons -->
+  <browser:page
+      for="*"
+      name="storage_discard_samples"
+      class=".discard_samples.DiscardSamplesView"
+      permission="senaite.core.permissions.ManageAnalysisRequests"
+      layer="senaite.storage.interfaces.ISenaiteStorageLayer" />
+
+</configure>

--- a/src/senaite/storage/browser/samples/discard_samples.py
+++ b/src/senaite/storage/browser/samples/discard_samples.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.STORAGE.
+#
+# SENAITE.STORAGE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2019-2024 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from bika.lims import api
+from bika.lims.interfaces import IAnalysisRequest
+from Products.CMFCore.WorkflowCore import WorkflowException
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from senaite.storage import PRODUCT_NAME
+from senaite.storage import senaiteMessageFactory as _
+from senaite.storage.browser import BaseView
+
+
+class DiscardSamplesView(BaseView):
+    """Action URL for the sample "discard" transition
+    """
+    template = ViewPageTemplateFile("templates/discard_samples.pt")
+
+    def __init__(self, context, request):
+        super(DiscardSamplesView, self).__init__(context, request)
+        self.context = context
+        self.request = request
+        self.portal = api.get_portal()
+        self.back_url = api.get_url(self.context)
+
+    def __call__(self):
+        form = self.request.form
+
+        # form submit toggle
+        submitted = form.get("submitted", False)
+        discard = form.get("button_discard", False)
+        cancel = form.get("button_cancel", False)
+
+        # handle discard action
+        if submitted and discard:
+            reasons = form.get("reasons", [])
+            comment = form.get("comment", "").strip()
+            reasons.extend(comment.split("\r\n"))
+            reasons = filter(None, reasons)
+
+            # convert to a single string
+            reasons = "\r\n".join(reasons)
+
+            # strip off leading and trailing escape sequences
+            reasons = reasons.strip("\n\r\t")
+
+            if not reasons:
+                return self.redirect(
+                    redirect_url=self.request.getHeader("http_referer"),
+                    message=_("Please specify a reason"), level="error")
+
+            # discard the samples
+            for sample in self.get_samples():
+                self.discard(sample, reasons)
+
+            return self.redirect()
+
+        # handle cancel
+        if submitted and cancel:
+            return self.redirect(message=_("Discard action was cancelled"))
+
+        return self.template()
+
+    def get_reasons(self):
+        """Returns the predefined list of reasons for discarding samples
+        """
+        key = "{}.discard_reasons".format(PRODUCT_NAME)
+        return api.get_registry_record(key, default=True)
+
+    def get_samples(self):
+        """Returns the samples from the request UIDs
+        """
+        objects = self.get_objects_from_request()
+        return filter(IAnalysisRequest.providedBy, objects)
+
+    def get_samples_data(self):
+        """Return a list of dicts representing the samples to be discarded
+        """
+        for obj in self.get_samples():
+            obj = api.get_object(obj)
+            yield {
+                "obj": obj,
+                "id": api.get_id(obj),
+                "uid": api.get_uid(obj),
+                "title": api.get_title(obj),
+                "url": api.get_url(obj),
+                "sample_type": obj.getSampleTypeTitle(),
+            }
+
+    def discard(self, sample, comment):
+        """Dispatch the sample
+        """
+        wf = api.get_tool("portal_workflow")
+        try:
+            wf.doActionFor(sample, "discard", comment=comment)
+            return True
+        except WorkflowException:
+            return False

--- a/src/senaite/storage/browser/samples/templates/discard_samples.pt
+++ b/src/senaite/storage/browser/samples/templates/discard_samples.pt
@@ -1,0 +1,113 @@
+<html xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns="http://www.w3.org/1999/xhtml"
+      metal:use-macro="here/main_template/macros/master"
+      i18n:domain="senaite.storage">
+<head>
+  <metal:block fill-slot="senaite_legacy_resources"
+               tal:define="portal context/@@plone_portal_state/portal;">
+  </metal:block>
+</head>
+<body>
+
+  <!-- Title -->
+  <metal:title fill-slot="content-title">
+    <h1 i18n:translate="">
+      Discard samples
+    </h1>
+  </metal:title>
+
+  <!-- Description -->
+  <metal:description fill-slot="content-description">
+    <p i18n:translate="">
+      <a tal:attributes="href view/back_url"
+         i18n:name="back_link"
+         i18n:translate="">
+        &larr; Back
+      </a>
+    </p>
+  </metal:description>
+
+  <!-- Content -->
+  <metal:core fill-slot="content-core">
+    <div id="dispatch-samples-view"
+         class="row"
+         tal:define="portal    context/@@plone_portal_state/portal;
+                     reasons   view/get_reasons;">
+
+      <div class="col-sm-12">
+        <form class="form rowlike"
+              id="discard_samples_form"
+              name="discard_samples_form"
+              method="post">
+
+          <!-- Hidden Fields -->
+          <input type="hidden" name="submitted" value="1"/>
+          <input tal:replace="structure context/@@authenticator/authenticator"/>
+
+          <div i18n:translate="" class="mb-3 text-secondary">
+            The following sample(s) will be discarded
+          </div>
+
+          <ul class="list mb-3" tal:repeat="sample view/get_samples_data">
+            <li class="list-item">
+              <input type="hidden" name="uids:list"
+                     tal:attributes="value sample/uid"/>
+              <div class="list-group-item-heading">
+                <a href="#" tal:attributes="href sample/url">
+                  <span tal:content="sample/title"/>
+                  <small>(<span tal:replace="sample/sample_type"/>)</small>
+                </a>
+              </div>
+            </li>
+          </ul>
+
+          <div class="mb-3 field" tal:condition="reasons">
+            <label for="reasons" i18n:translate="">Pre-defined reasons</label>
+            <div class="form-control-sm mr-2"
+                 tal:repeat="reason reasons">
+              <input type="checkbox"
+                     tal:define="idx repeat/reason/index;"
+                     tal:attributes="value string:${reason};"
+                     name="reasons:list"/>
+              <span tal:content="reason" />
+            </div>
+          </div>
+
+          <div class="mb-3 field">
+            <tal:with_reasons condition="reasons">
+              <label for="comment" i18n:translate="">Other reasons</label>
+            </tal:with_reasons>
+            <tal:wo_reasons condition="not:reasons">
+              <label for="comment" i18n:translate="">Reasons</label>
+              <span class="required"/>
+            </tal:wo_reasons>
+            <textarea name="comment"
+                      class="form-control"
+                      id="comment"
+                      placeholder=""
+                      style="height: 150px"/>
+          </div>
+
+          <!-- Form Controls -->
+          <div>
+            <input class="btn btn-primary btn-sm"
+                   type="submit"
+                   name="button_discard"
+                   i18n:attributes="value"
+                   value="Discard"/>
+            <input class="btn btn-secondary btn-sm"
+                   type="submit"
+                   name="button_cancel"
+                   i18n:attributes="value"
+                   value="Cancel"/>
+          </div>
+
+        </form>
+      </div>
+
+    </div>
+  </metal:core>
+
+</body>
+</html>

--- a/src/senaite/storage/browser/viewlets/configure.zcml
+++ b/src/senaite/storage/browser/viewlets/configure.zcml
@@ -2,6 +2,16 @@
            xmlns:browser="http://namespaces.zope.org/browser"
            i18n_domain="senaite.storage">
 
+  <!-- Sample discarded viewlet -->
+  <browser:viewlet
+      for="bika.lims.interfaces.IAnalysisRequest"
+      name="senaite.storage.sample_discarded_viewlet"
+      class=".sample_discarded.SampleDiscardedViewlet"
+      manager="plone.app.layout.viewlets.interfaces.IAboveContent"
+      template="templates/sample_discarded_viewlet.pt"
+      permission="zope2.View"
+      layer="senaite.storage.interfaces.ISenaiteStorageLayer" />
+
   <!-- Storage container viewlet displayed in samples -->
   <browser:viewlet
       for="bika.lims.interfaces.IAnalysisRequest"

--- a/src/senaite/storage/browser/viewlets/sample_discarded.py
+++ b/src/senaite/storage/browser/viewlets/sample_discarded.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.STORAGE.
+#
+# SENAITE.STORAGE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2019-2024 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from bika.lims import api
+from plone.app.layout.viewlets import ViewletBase
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from senaite.core.api import dtime
+
+
+class SampleDiscardedViewlet(ViewletBase):
+    """Print a viewlet showing the WF history comment from a discarded sample
+    """
+
+    index = ViewPageTemplateFile("templates/sample_discarded_viewlet.pt")
+
+    def __init__(self, context, request, view, manager=None):
+        super(SampleDiscardedViewlet, self).__init__(
+            context, request, view, manager=manager)
+        self.context = context
+        self.request = request
+        self.view = view
+
+    def is_discarded(self):
+        """Returns whether the current sample is discarded
+        """
+        return api.get_review_status(self.context) == "discarded"
+
+    def get_state_info(self):
+        """Returns the WF state information
+        """
+        history = api.get_review_history(self.context)
+        entry = len(history) and history[0] or {}
+        actor = entry.get("actor")
+        props = api.get_user_properties(actor) or {}
+        date = entry.get("time")
+        comments = entry.get("comments", "")
+        comments = api.safe_unicode(comments)
+        comments = comments.split("\r\n")
+        return {
+            "actor": props.get("fullname", actor),
+            "date": dtime.to_localized_time(date, long_format=True),
+            "comments": comments,
+        }

--- a/src/senaite/storage/browser/viewlets/templates/sample_discarded_viewlet.pt
+++ b/src/senaite/storage/browser/viewlets/templates/sample_discarded_viewlet.pt
@@ -1,6 +1,6 @@
 <div tal:omit-tag=""
      tal:condition="python: view.is_discarded()"
-     i18n:domain="senaite.strorage">
+     i18n:domain="senaite.storage">
 
   <div id="portal-alert"
        tal:define="info python:view.get_state_info()">

--- a/src/senaite/storage/browser/viewlets/templates/sample_discarded_viewlet.pt
+++ b/src/senaite/storage/browser/viewlets/templates/sample_discarded_viewlet.pt
@@ -1,0 +1,25 @@
+<div tal:omit-tag=""
+     tal:condition="python: view.is_discarded()"
+     i18n:domain="senaite.strorage">
+
+  <div id="portal-alert"
+       tal:define="info python:view.get_state_info()">
+    <div class="portlet-alert-item alert alert-secondary alert-dismissible">
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <p class="title">
+        <strong i18n:translate="this_sample_has_been_dispatched_by">
+          This sample has been discarded by
+          <span i18n:name="actor" tal:replace="info/actor"/>, on
+          <span i18n:name="date" tal:replace="info/date"/>, because of the
+          following reasons:
+        </strong>
+      </p>
+      <p class="description"
+         tal:repeat="comment info/comments"
+         tal:content="comment"/>
+    </div>
+  </div>
+
+</div>

--- a/src/senaite/storage/browser/workflow/analysisrequest.py
+++ b/src/senaite/storage/browser/workflow/analysisrequest.py
@@ -35,3 +35,16 @@ class WorkflowActionStoreAdapter(RequestContextAware):
         url = "{}/storage_store_samples?uids={}".format(
             api.get_url(self.context), ",".join(uids))
         return self.redirect(redirect_url=url)
+
+
+@implementer(IWorkflowActionUIDsAdapter)
+class WorkflowActionDiscardAdapter(RequestContextAware):
+    """Adapter in charge of the Sample's 'discard' action
+    """
+
+    def __call__(self, action, uids):
+        """Redirects the user to the Storage container selector view
+        """
+        url = "{}/storage_discard_samples?uids={}".format(
+            api.get_url(self.context), ",".join(uids))
+        return self.redirect(redirect_url=url)

--- a/src/senaite/storage/browser/workflow/configure.zcml
+++ b/src/senaite/storage/browser/workflow/configure.zcml
@@ -14,6 +14,18 @@
     provides="bika.lims.interfaces.IWorkflowActionAdapter"
     permission="zope.Public" />
 
+  <!-- Workflow action "store"
+  Note this applies wide, cause at the moment, this action only exists
+  for Samples and we always want this adapter to be in charge, regardless of
+  the context (Analysis Requests listing, Client folder, etc.) -->
+  <adapter
+      name="workflow_action_discard"
+      for="*
+           zope.publisher.interfaces.browser.IBrowserRequest"
+      factory=".analysisrequest.WorkflowActionDiscardAdapter"
+      provides="bika.lims.interfaces.IWorkflowActionAdapter"
+      permission="zope.Public" />
+
   <!-- Workflow action "add_samples" -->
   <adapter
     name="workflow_action_add_samples"

--- a/src/senaite/storage/browser/workflow/configure.zcml
+++ b/src/senaite/storage/browser/workflow/configure.zcml
@@ -14,10 +14,7 @@
     provides="bika.lims.interfaces.IWorkflowActionAdapter"
     permission="zope.Public" />
 
-  <!-- Workflow action "store"
-  Note this applies wide, cause at the moment, this action only exists
-  for Samples and we always want this adapter to be in charge, regardless of
-  the context (Analysis Requests listing, Client folder, etc.) -->
+  <!-- Workflow action "discard" -->
   <adapter
       name="workflow_action_discard"
       for="*

--- a/src/senaite/storage/permissions.py
+++ b/src/senaite/storage/permissions.py
@@ -27,6 +27,7 @@ AddStoragePosition = "senaite.storage: Add Storage Position"
 # Permissions when context is a sample
 TransitionStoreSample = "senaite.storage: Transition: Store Sample"
 TransitionRecoverSample = "senaite.storage: Transition: Recover Sample"
+TransitionDiscardSample = "senaite.storage: Transition: Discard Sample"
 
 # Permissions when context is a storage samples container
 TransitionAddSamples = "senaite.storage: Transition: Add Samples"

--- a/src/senaite/storage/permissions.zcml
+++ b/src/senaite/storage/permissions.zcml
@@ -9,9 +9,10 @@
   <permission id="senaite.storage.permissions.AddStorageSamplesContainer" title="senaite.storage: Add Storage Samples Container"/>
   <permission id="senaite.storage.permissions.AddStoragePosition" title="senaite.storage: Add Storage Position"/>
 
-  <!-- Store/Recover Sample Permissions (context is a sample) -->
+  <!-- Store/Recover/Discard Sample Permissions (context is a sample) -->
   <permission id="senaite.storage.permissions.StoreSample" title="senaite.storage: Transition: Store Sample"/>
   <permission id="senaite.storage.permissions.RecoverSample" title="senaite.storage: Transition: Recover Sample"/>
+  <permission id="senaite.storage.permissions.DiscardSample" title="senaite.storage: Transition: Discard Sample"/>
 
   <!-- Add/Recover Samples Permissions (context is a storage container) -->
   <permission id="senaite.storage.permissions.AddSamples" title="senaite.storage: Transition: Add Samples"/>

--- a/src/senaite/storage/profiles/default/metadata.xml
+++ b/src/senaite/storage/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>2602</version>
+  <version>2603</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/senaite/storage/profiles/default/rolemap.xml
+++ b/src/senaite/storage/profiles/default/rolemap.xml
@@ -43,6 +43,11 @@
       <role name="LabManager"/>
       <role name="Manager"/>
     </permission>
+    <permission name="senaite.storage: Transition: Discard Sample" acquire="False">
+      <role name="LabClerk"/>
+      <role name="LabManager"/>
+      <role name="Manager"/>
+    </permission>
 
     <!-- Add/Recover Samples Transition Permissions (storage listings) -->
     <permission name="senaite.storage: Transition: Add Samples" acquire="False">

--- a/src/senaite/storage/setuphandlers.py
+++ b/src/senaite/storage/setuphandlers.py
@@ -162,7 +162,7 @@ WORKFLOWS_TO_UPDATE = {
             "store": {
                 "title": "Store",
                 "new_state": "stored",
-                "action": "Store sample",
+                "action": "Store",
                 "guard": {
                     "guard_permissions": "senaite.storage: Transition: Store Sample",  # noqa
                     "guard_roles": "",
@@ -174,7 +174,7 @@ WORKFLOWS_TO_UPDATE = {
                 # We set same new_state here because system will transition the
                 # sample to the state before when was stored. See events
                 "new_state": "stored",
-                "action": "Recover sample",
+                "action": "Recover",
                 "guard": {
                     "guard_permissions": "senaite.storage: Transition: Recover Sample",  # noqa
                     "guard_roles": "",
@@ -184,7 +184,7 @@ WORKFLOWS_TO_UPDATE = {
             "discard": {
                 "title": "Discard",
                 "new_state": "discarded",
-                "action": "Discard sample",
+                "action": "Discard",
                 "guard": {
                     "guard_permissions": TransitionDiscardSample,
                     "guard_roles": "",

--- a/src/senaite/storage/setuphandlers.py
+++ b/src/senaite/storage/setuphandlers.py
@@ -35,6 +35,7 @@ from senaite.storage.catalog import STORAGE_CATALOG
 from senaite.storage.catalog import StorageCatalog
 from senaite.storage.config import PRODUCT_NAME
 from senaite.storage.config import PROFILE_ID
+from senaite.storage.permissions import TransitionDiscardSample
 
 ACTIONS_TO_HIDE = [
     # Tuples of (id, folder_id)
@@ -131,7 +132,7 @@ WORKFLOWS_TO_UPDATE = {
             "stored": {
                 "title": "Stored",
                 "description": "Sample is stored",
-                "transitions": ("recover", "detach", "dispatch", ),
+                "transitions": ("recover", "detach", "dispatch", "discard"),
                 # Copy permissions from sample_received first
                 "permissions_copy_from": "sample_received",
                 # Override permissions
@@ -149,6 +150,12 @@ WORKFLOWS_TO_UPDATE = {
                     permissions.TransitionScheduleSampling: (),
                     ModifyPortalContent: (),
                 }
+            },
+            "discarded": {
+                "title": "Discarded",
+                "description": "Sample is discarded",
+                # discarded is an end-non-writable-state, like rejected
+                "permissions_copy_from": "rejected",
             },
         },
         "transitions": {
@@ -174,6 +181,16 @@ WORKFLOWS_TO_UPDATE = {
                     "guard_expr": "python:here.guard_handler('recover')",
                 }
             },
+            "discard": {
+                "title": "Discard",
+                "new_state": "discarded",
+                "action": "Discard sample",
+                "guard": {
+                    "guard_permissions": TransitionDiscardSample,
+                    "guard_roles": "",
+                    "guard_expr": "python:here.guard_handler('discard')",
+                }
+            }
         }
     }
 }

--- a/src/senaite/storage/upgrade/v02_06_000.py
+++ b/src/senaite/storage/upgrade/v02_06_000.py
@@ -91,7 +91,11 @@ def setup_discard_transition(tool):
     wf_tool = api.get_tool("portal_workflow")
     wf = wf_tool.getWorkflowById(SAMPLE_WORKFLOW)
 
-    # re-import rolemap for new permisisons to become effective
+    # re-import storage registry to add predefined options for discard action
+    setup.runImportStepFromProfile(profile, "controlpanel")
+    setup.runImportStepFromProfile(profile, "plone.app.registry")
+
+    # re-import rolemap for new permissions to become effective
     setup.runImportStepFromProfile(profile, "rolemap")
 
     # setup storage-specific workflow for new actions and statuses to apply

--- a/src/senaite/storage/upgrade/v02_06_000.zcml
+++ b/src/senaite/storage/upgrade/v02_06_000.zcml
@@ -3,6 +3,14 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="SENAITE.STORAGE 2.6.0: Setup discard action for stored samples"
+      description="Setup discard action for stored samples"
+      source="2602"
+      destination="2603"
+      handler=".v02_06_000.setup_discard_transition"
+      profile="senaite.storage:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.STORAGE 2.6.0: Setup Storage's control panel"
       description="Setup Storage's control panel"
       source="2601"

--- a/src/senaite/storage/workflow/configure.zcml
+++ b/src/senaite/storage/workflow/configure.zcml
@@ -2,6 +2,9 @@
     xmlns="http://namespaces.zope.org/zope"
     i18n_domain="senaite.storage">
 
+  <!-- Package includes -->
+  <include package=".sample" />
+
   <!-- Guards adapter -->
   <adapter
       for="senaite.storage.interfaces.IStorageContent"

--- a/src/senaite/storage/workflow/sample/configure.zcml
+++ b/src/senaite/storage/workflow/sample/configure.zcml
@@ -1,0 +1,12 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    i18n_domain="senaite.storage">
+
+  <!-- Sample guards adapter -->
+  <adapter
+      for="bika.lims.interfaces.IAnalysisRequest"
+      provides="bika.lims.interfaces.IGuardAdapter"
+      factory=".guards.SampleGuardsAdapter"
+      name="senaite.storage.workflow.sample.guards" />
+
+</configure>

--- a/src/senaite/storage/workflow/sample/events.py
+++ b/src/senaite/storage/workflow/sample/events.py
@@ -45,6 +45,13 @@ def is_recover_primary_enabled():
     return api.get_registry_record(key, default=True)
 
 
+def after_discard(sample):
+    """Event triggered after "discard" action takes place for a given sample
+    """
+    # remove the sample from the container
+    _api.remove_sample_from_container(sample)
+
+
 def before_dispatch(sample):
     """Event triggered before "dispatch" transition takes place for a given sample
     """

--- a/src/senaite/storage/workflow/sample/events.py
+++ b/src/senaite/storage/workflow/sample/events.py
@@ -81,7 +81,7 @@ def after_store(sample):
     parts = primary.getDescendants()
 
     # Partitions in some statuses won't be considered
-    skip = ["cancelled", "stored", "retracted", "rejected"]
+    skip = ["cancelled", "stored", "retracted", "rejected", "discarded"]
     parts = filter(lambda part: api.get_review_status(part) not in skip, parts)
     if not parts:
         # There are no partitions left, transition the primary
@@ -118,7 +118,7 @@ def after_recover(sample):
     parts = primary.getDescendants()
 
     # Partitions in some statuses won't be considered.
-    skip = ["cancelled", "stored", "retracted", "rejected"]
+    skip = ["cancelled", "stored", "retracted", "rejected", "discarded"]
     parts = filter(lambda part: api.get_review_status(part) in skip, parts)
     if not parts:
         # There are no partitions left, transition the primary

--- a/src/senaite/storage/workflow/sample/guards.py
+++ b/src/senaite/storage/workflow/sample/guards.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.STORAGE.
+#
+# SENAITE.STORAGE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2019-2024 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from bika.lims import api
+from senaite.storage.workflow.guards import GuardsAdapter
+
+
+class SampleGuardsAdapter(GuardsAdapter):
+    """Guards adapter for Sample content type
+    """
+
+    def guard_discard(self, sample):
+        """Returns True if the sample does not have analyses assigned and does
+        not have non-rejected partitions
+        """
+        # cannot discard samples with requested analyses
+        if sample.getAnalyses(full_objects=False):
+            return False
+
+        # all partitions have to be discarded
+        for uid in sample.getDescendantsUIDs():
+            part = api.get_object_by_uid(uid)
+            if api.get_review_status(part) != "discarded":
+                return False
+
+        return True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request allows to discard samples from storage and assign underlying reason(s), that can either be from a predefined set of options accessible in control panel or manually typed

![Captura de 2024-01-29 13-09-52](https://github.com/senaite/senaite.storage/assets/832627/ea5c1f35-77ca-4f9d-9434-1ea33695b738)

![Captura de 2024-01-29 13-11-19](https://github.com/senaite/senaite.storage/assets/832627/57ed56e4-0d3a-4806-a2b8-5639ce70fe54)

![Captura de 2024-01-29 13-11-51](https://github.com/senaite/senaite.storage/assets/832627/d0a2526e-3cbc-4497-99de-df2beff45920)


## Current behavior before PR

Is not possible to discard samples

## Desired behavior after PR is merged

Is possible to discard samples

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
