### PR TITLE
Update permission imports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #47 Update permissions imports
 - #44 Compatibility with core#2567 (AnalysisCategory to DX)
 - #42 Compatibility with core#2471 (Department to DX)
 - #39 Add storage settings for auto-store/recover of primary sample

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
-- #47 Update permissions imports
+- #47 Update permission imports
 - #46 Compatibility with core#2584 (SampleType to DX)
 - #44 Compatibility with core#2567 (AnalysisCategory to DX)
 - #42 Compatibility with core#2471 (Department to DX)

--- a/src/senaite/storage/setuphandlers.py
+++ b/src/senaite/storage/setuphandlers.py
@@ -20,11 +20,11 @@
 
 from Acquisition import aq_base
 from bika.lims import api
-from bika.lims import permissions
 from plone import api as ploneapi
 from Products.CMFCore.permissions import ModifyPortalContent
 from Products.CMFPlone.utils import _createObjectByType
 from Products.DCWorkflow.Guard import Guard
+from senaite.core import permissions
 from senaite.core.catalog import SAMPLE_CATALOG
 from senaite.core.setuphandlers import setup_catalog_mappings
 from senaite.core.setuphandlers import setup_core_catalogs

--- a/src/senaite/storage/tests/doctests/PrimarySample.rst
+++ b/src/senaite/storage/tests/doctests/PrimarySample.rst
@@ -42,7 +42,8 @@ Variables:
 
     >>> portal = self.portal
     >>> request = self.request
-    >>> setup = api.get_setup()
+    >>> setup = api.get_senaite_setup()
+    >>> bika_setup = api.get_bika_setup()
     >>> storage = portal.senaite_storage
 
 Assign default roles for the user to test with:
@@ -60,12 +61,12 @@ Create some baseline objects for the test:
     >>> client = api.create(portal.clients, "Client", Name="Happy Hills", ClientID="HH", MemberDiscountApplies=True)
     >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
     >>> sampletype = api.create(setup.sampletypes, "SampleType", title="Water", Prefix="W")
-    >>> labcontact = api.create(setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
-    >>> department = api.create(portal.setup.departments, "Department", title="Chemistry", Manager=labcontact)
-    >>> category = api.create(portal.setup.analysiscategories, "AnalysisCategory", title="Metals", Department=department)
-    >>> Cu = api.create(setup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Price="15", Category=category.UID(), Accredited=True)
-    >>> Fe = api.create(setup.bika_analysisservices, "AnalysisService", title="Iron", Keyword="Fe", Price="10", Category=category.UID())
-    >>> Au = api.create(setup.bika_analysisservices, "AnalysisService", title="Gold", Keyword="Au", Price="20", Category=category.UID())
+    >>> labcontact = api.create(bika_setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(setup.departments, "Department", title="Chemistry", Manager=labcontact)
+    >>> category = api.create(setup.analysiscategories, "AnalysisCategory", title="Metals", Department=department)
+    >>> Cu = api.create(bika_setup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Price="15", Category=category.UID(), Accredited=True)
+    >>> Fe = api.create(bika_setup.bika_analysisservices, "AnalysisService", title="Iron", Keyword="Fe", Price="10", Category=category.UID())
+    >>> Au = api.create(bika_setup.bika_analysisservices, "AnalysisService", title="Gold", Keyword="Au", Price="20", Category=category.UID())
 
 Auto-transition primary sample
 ..............................


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the permission imports from `bika.lims.permissions` to `senaite.core.permissions` that was done in https://github.com/senaite/senaite.core/pull/2298

## Current behavior before PR

Deprecation warnings are displayed

## Desired behavior after PR is merged

No deprecation warnings are displayed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
