### PR TITLE
Migrate storage container to DX

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #49 Migrate storage container to DX
 - #48 Migrate Storage Facility to DX
 
 

--- a/src/senaite/storage/browser/container/view.py
+++ b/src/senaite/storage/browser/container/view.py
@@ -51,7 +51,7 @@ class ContainerListingView(FacilityListingView):
 
         self.context_actions = collections.OrderedDict((
             (_("Add container"), {
-                "url": "createObject?type_name=StorageContainer",
+                "url": "++add++StorageContainer",
                 "permission": AddStorageContainer,
                 "icon": "{}/{}".format(
                     self.icon_path, "storage-container"),

--- a/src/senaite/storage/browser/facility/view.py
+++ b/src/senaite/storage/browser/facility/view.py
@@ -60,7 +60,7 @@ class FacilityListingView(StorageListing):
                 "icon": "{}/{}".format(self.icon_path, "storage-position"),
             }),
             (_("Add container"), {
-                "url": "createObject?type_name=StorageContainer",
+                "url": "++add++StorageContainer",
                 "permission": AddStorageContainer,
                 "icon": "{}/{}".format(self.icon_path, "storage-container"),
             }),

--- a/src/senaite/storage/content/storage_container.py
+++ b/src/senaite/storage/content/storage_container.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+
+from AccessControl import ClassSecurityInfo
+from bika.lims import api
+from plone.autoform import directives
+from Products.CMFCore import permissions
+from senaite.storage import senaiteMessageFactory as _
+from senaite.storage.catalog import STORAGE_CATALOG
+from senaite.storage.content.storage_layout_container import \
+    StorageLayoutContainer
+from senaite.storage.content.storage_layout_container import \
+    IStorageLayoutContainerSchema
+from senaite.storage.interfaces import IStorageContainer
+from z3c.form.interfaces import IEditForm
+from zope import schema
+from zope.interface import implementer
+
+
+class IStorageContainerSchema(IStorageLayoutContainerSchema):
+
+    title = schema.TextLine(
+        title=_(
+            u"title_storage_container_title",
+            default=u"Name"
+        ),
+        required=True)
+
+    directives.widget("temperature", klass="numeric")
+    temperature = schema.TextLine(
+        title=_(
+            u"title_storage_container_temperature",
+            default=u"Temperature"
+        ),
+        description=_(
+            u"description_storage_container_temperature",
+            default=u"Expected temperature of this container"),
+        required=False)
+
+    directives.omitted(IEditForm, "description")
+    description = schema.Text(
+        title=_(
+            u"title_storage_container_description",
+            default=u"Description"
+        ),
+        required=False,
+    )
+
+    directives.omitted("rows")
+    directives.omitted("columns")
+    directives.omitted("positions_layout")
+    directives.omitted("available_positions")
+
+
+@implementer(IStorageContainer, IStorageContainerSchema)
+class StorageContainer(StorageLayoutContainer):
+    """A Storage container
+    """
+    _catalogs = [STORAGE_CATALOG]
+
+    security = ClassSecurityInfo()
+
+    @security.protected(permissions.View)
+    def Description(self):
+        temperature = self.getTemperature() or "-"
+        return _(u"Expected temperature: %s °C" % temperature)
+
+    @security.protected(permissions.View)
+    def getTemperature(self):
+        accessor = self.accessor("temperature")
+        return accessor(self)
+
+    @security.protected(permissions.ModifyPortalContent)
+    def setTemperature(self, value):
+        mutator = self.mutator("temperature")
+        value = str(api.to_float(value, 0))
+        mutator(self, value)
+
+    # BBB: AT schema field property
+    Temperature = property(getTemperature, setTemperature)

--- a/src/senaite/storage/content/storage_layout_container.py
+++ b/src/senaite/storage/content/storage_layout_container.py
@@ -78,7 +78,6 @@ class IStorageLayoutContainerSchema(model.Schema):
         default=[],
     )
 
-    # XXX: Where is this used?
     directives.widget("available_positions", TextLinesFieldWidget)
     available_positions = schema.List(
         title=_("Available Positions"),
@@ -120,8 +119,9 @@ class IStorageLayoutContainerSchema(model.Schema):
 class StorageLayoutContainer(Container):
     """A storage layout container
     """
-
     security = ClassSecurityInfo()
+
+    default_samples_capacity = 1
 
     @security.protected(permissions.View)
     def Description(self):
@@ -175,10 +175,9 @@ class StorageLayoutContainer(Container):
         return accessor(self)
 
     @security.protected(permissions.ModifyPortalContent)
-    def setPositionsLayout(self, values):
-        mutator = self.mutator("positions_layout")
+    def setAvailablePositions(self, values):
+        mutator = self.mutator("available_positions")
         mutator(self, values)
-        self.rebuild_layout()
 
     # BBB: AT schema field property
     PositionsLayout = property(getPositionsLayout, setPositionsLayout)
@@ -254,7 +253,8 @@ class StorageLayoutContainer(Container):
                 item = self.get_item_at(num_row, num_col)
                 new_item = item and item.copy() or new_item
                 new_layout.append(new_item)
-        self.getField("PositionsLayout").set(self, new_layout)
+        # bypass setter
+        self.positions_layout = new_layout
         available = map(lambda el: self.position_to_alpha(el[0], el[1]),
                         self.get_available_positions())
         self.setAvailablePositions(available)
@@ -342,7 +342,7 @@ class StorageLayoutContainer(Container):
                      self.getPositionsLayout())
         if not els:
             return None
-        return (api.to_int(els[0]['row']), api.to_int(els[0]['column']))
+        return (api.to_int(els[0]["row"]), api.to_int(els[0]["column"]))
 
     def has_object(self, object_brain_uid):
         """Returns if the container contains the object passed in
@@ -379,8 +379,8 @@ class StorageLayoutContainer(Container):
         container can have without removing any of the objects it contains
         """
         els = filter(self.is_taken, self.getPositionsLayout())
-        rows = map(lambda el: api.to_int(el['row']), els) or [0]
-        cols = map(lambda el: api.to_int(el['column']), els) or [0]
+        rows = map(lambda el: api.to_int(el["row"]), els) or [0]
+        cols = map(lambda el: api.to_int(el["column"]), els) or [0]
         return (max(rows)+1, max(cols)+1)
 
     def get_capacity(self):

--- a/src/senaite/storage/content/storage_layout_container.py
+++ b/src/senaite/storage/content/storage_layout_container.py
@@ -1,0 +1,570 @@
+# -*- coding: utf-8 -*-
+
+import re
+import string
+
+from AccessControl import ClassSecurityInfo
+from bika.lims import api
+from plone.autoform import directives
+from plone.supermodel import model
+from Products.CMFCore import permissions
+from senaite.core.content.base import Container
+from senaite.core.z3cform.widgets.datagrid import DataGridWidgetFactory
+from senaite.core.z3cform.widgets.number import NumberWidget
+from senaite.storage import logger
+from senaite.storage import senaiteMessageFactory as _
+from senaite.storage.interfaces import IStorageBreadcrumbs
+from senaite.storage.interfaces import IStorageFacility
+from senaite.storage.interfaces import IStorageLayoutContainer
+from z3c.form.browser.textlines import TextLinesFieldWidget
+from zope import schema
+from zope.interface import Interface, Invalid, invariant
+from zope.interface import implementer
+
+
+class IPositionLayoutItem(Interface):
+    row = schema.Int(title=_("Row"))
+    column = schema.Int(title=_("Column"))
+    uid = schema.TextLine(title=_("UID"))
+    samples_capacity = schema.Int(title=_("Samples Capacity"), default=0)
+    samples_utilization = schema.Int(title=_("Samples Utilization"), default=0)
+
+
+class IStorageLayoutContainerSchema(model.Schema):
+
+    directives.widget("rows", NumberWidget)
+    rows = schema.Int(
+        title=_(
+            u"title_storage_layout_container_rows",
+            default=u"Rows"
+        ),
+        description=_(
+            u"description_storage_layout_container_rows",
+            default=u"Alphabet letters will be used to represent a row "
+            "within the container"),
+        default=1,
+        required=True,
+    )
+
+    directives.widget("columns", NumberWidget)
+    columns = schema.Int(
+        title=_(
+            u"title_storage_layout_container_columns",
+            default=u"Columns"
+        ),
+        description=_(
+            u"description_storage_layout_container_columns",
+            default=u"Number of positions per row. Numbers will be used to "
+            "represent a column within a row"),
+        default=1,
+        required=True,
+    )
+
+    # This field is not editable and is generated automatically based on the
+    # rows, columns and occupied positions. It returns a list of dicts. Each
+    # dict represents an object stored within this container at the given
+    # 'column' and 'row' keys. The UID of the object is stored as a value for
+    # the key 'uid'.  "capacity" refers to the number of samples the contained
+    # object can store directly or indirectly (through other child containers).
+    # "utilization" field refers to the number of sample the contained object
+    # actually stores directly or indirectly.
+    # The total capacity and utilization of this container is the sum of values
+    # of the capacity and utilization of the objects this container stores.
+    directives.widget("positions_layout", DataGridWidgetFactory)
+    positions_layout = schema.List(
+        title=_("Positions Layout"),
+        value_type=schema.Object(schema=IPositionLayoutItem),
+        required=False,
+        default=[],
+    )
+
+    # XXX: Where is this used?
+    directives.widget("available_positions", TextLinesFieldWidget)
+    available_positions = schema.List(
+        title=_("Available Positions"),
+        required=False,
+        value_type=schema.TextLine(),
+        default=[],
+    )
+
+    @invariant
+    def validate_rows(data):
+        """Checks if the email is correct
+        """
+        if not data.rows:
+            return
+        if not data.rows > 0:
+            raise Invalid(_("At least one row must be defined"))
+        context = data.__context__
+        min_size = context.get_minimum_size()
+        min_rows = min_size[0]
+        if min_rows > data.rows:
+            raise Invalid(_("At least %s rows must be remain" % min_rows))
+
+    @invariant
+    def validate_columns(data):
+        """Checks if the email is correct
+        """
+        if not data.columns:
+            return
+        if not data.columns > 0:
+            raise Invalid(_("At least one column must be defined"))
+        context = data.__context__
+        min_size = context.get_minimum_size()
+        min_cols = min_size[1]
+        if min_cols > data.columns:
+            raise Invalid(_("At least %s columns must be remain" % min_cols))
+
+
+@implementer(IStorageLayoutContainer, IStorageLayoutContainerSchema)
+class StorageLayoutContainer(Container):
+    """A storage layout container
+    """
+
+    security = ClassSecurityInfo()
+
+    @security.protected(permissions.View)
+    def Description(self):
+        return _("Layout: {} x {}".format(self.rows, self.columns))
+
+    @security.protected(permissions.View)
+    def getRows(self):
+        accessor = self.accessor("rows")
+        return accessor(self)
+
+    @security.protected(permissions.ModifyPortalContent)
+    def setRows(self, value):
+        mutator = self.mutator("rows")
+        mutator(self, value)
+        self.rebuild_layout()
+
+    # BBB: AT schema field property
+    Rows = property(getRows, setRows)
+
+    @security.protected(permissions.View)
+    def getColumns(self):
+        accessor = self.accessor("columns")
+        return accessor(self)
+
+    @security.protected(permissions.ModifyPortalContent)
+    def setColumns(self, value):
+        mutator = self.mutator("columns")
+        mutator(self, value)
+        self.rebuild_layout()
+
+    # BBB: AT schema field property
+    Columns = property(getColumns, setColumns)
+
+    @security.protected(permissions.View)
+    def getPositionsLayout(self):
+        accessor = self.accessor("positions_layout")
+        return accessor(self)
+
+    @security.protected(permissions.ModifyPortalContent)
+    def setPositionsLayout(self, values):
+        mutator = self.mutator("positions_layout")
+        mutator(self, values)
+        self.rebuild_layout()
+
+    # BBB: AT schema field property
+    PositionsLayout = property(getPositionsLayout, setPositionsLayout)
+
+    @security.protected(permissions.View)
+    def getAvailablePositions(self):
+        accessor = self.accessor("available_positions")
+        return accessor(self)
+
+    @security.protected(permissions.ModifyPortalContent)
+    def setPositionsLayout(self, values):
+        mutator = self.mutator("positions_layout")
+        mutator(self, values)
+        self.rebuild_layout()
+
+    # BBB: AT schema field property
+    PositionsLayout = property(getPositionsLayout, setPositionsLayout)
+
+    def get_full_title(self):
+        """Returns the full title of this container in breadcrumbs format
+        """
+        adapter = IStorageBreadcrumbs(self)
+        return adapter.get_storage_breadcrumbs()
+
+    def get_all_ids(self):
+        """Returns the list of ids this container is contained in, the id of the
+        current container included. Used as an index for catalog searches
+        """
+        def feed_parent_ids(container, ids):
+            ids.append(container.getId())
+            if IStorageFacility.providedBy(container.aq_parent):
+                return ids
+            return feed_parent_ids(container.aq_parent, ids)
+        return feed_parent_ids(self, [])
+
+    def get_default_layout_item(self, row=0, column=0):
+        """Returns a default item for the positions layout
+        """
+        return dict(row=row, column=column, uid="", samples_utilization=0,
+                    samples_capacity=self.default_samples_capacity)
+
+    def get_alpha_row(self, row):
+        """Returns the alpha part for the passed in row
+        """
+        alphabet = string.ascii_uppercase
+        num, idx = divmod(int(row), len(alphabet))
+        if num:
+            return self.get_alpha_column(num - 1) + alphabet[idx]
+        return alphabet[idx]
+
+    def position_to_alpha(self, row, column):
+        """Returns a position in alphanumeric format (e.g A01)
+        """
+        alpha_part = self.get_alpha_row(row)
+        lead_zeros = len(str(self.getColumns())) - 1
+        num_part = "%0{}d".format(lead_zeros) % (int(column) + 1)
+        return "{}{}".format(alpha_part, num_part)
+
+    def alpha_to_position(self, alpha):
+        """Converts an alphanumeric value to a position
+        """
+        alphabet = string.ascii_uppercase
+        regex = re.compile(r"([A-Z]+)(\d+)", re.IGNORECASE)
+        matches = re.findall(regex, alpha)
+        alpha_part = matches[0][0]
+        column = api.to_int(matches[0][1]) - 1
+        row = 0
+        mapping = map(lambda val: alphabet.index(val), alpha_part)
+        for idx in range(len(mapping)):
+            row += idx * len(alphabet) + mapping[idx]
+        return (row, column)
+
+    def get_absolute_position(self, row, column):
+        """Returns the absolute position for the row and column passed in
+        """
+        if not self.is_valid_position(row, column):
+            return -1
+        return row * self.getColumns() + column + 1
+
+    def rebuild_layout(self):
+        """Rebuilds the layout with all positions
+        """
+        new_layout = list()
+        for num_row in range(self.getRows()):
+            for num_col in range(self.getColumns()):
+                new_item = self.get_default_layout_item(num_row, num_col)
+                item = self.get_item_at(num_row, num_col)
+                new_item = item and item.copy() or new_item
+                new_layout.append(new_item)
+        self.getField("PositionsLayout").set(self, new_layout)
+        available = map(lambda el: self.position_to_alpha(el[0], el[1]),
+                        self.get_available_positions())
+        self.setAvailablePositions(available)
+
+    def is_valid_position(self, row, column):
+        """Returns whether the position defined is valid or not for this
+        container's layout
+        """
+        col_num = api.to_int(column, default=-1)
+        if col_num < 0 or col_num >= self.getColumns():
+            return False
+        row_num = api.to_int(row, default=-1)
+        if row_num < 0 or row_num >= self.getRows():
+            return False
+        return True
+
+    def is_empty_position(self, row, column):
+        """Returns whether the position defined is empty or not
+        """
+        return not self.is_taken_position(row, column)
+
+    def is_taken_position(self, row, column):
+        """Returns whether the position defined is taken or not
+        """
+        if not self.is_valid_position(row, column):
+            return True
+        item = self.get_item_at(row, column)
+        return item and self.is_taken(item) or False
+
+    def is_empty(self, item):
+        """Returns if an item from the layout is empty
+        """
+        return not self.is_taken(item)
+
+    def is_taken(self, item):
+        """Returns whether an item from the layout has an element assigned
+        """
+        return item.get("uid", "") and True or False
+
+    def get_available_positions(self):
+        """Returns a list of dics with available positions
+        """
+        els = filter(self.is_empty, self.getPositionsLayout())
+        return map(lambda el: (el["row"], el["column"]), els)
+
+    def get_non_available_positions(self):
+        """Returns a list of tuples with non-available positions
+        """
+        els = filter(self.is_taken, self.getPositionsLayout())
+        return map(lambda el: (el["row"], el["column"]), els)
+
+    def get_item_at(self, row, column):
+        """Returns the layout item this container contains at the given position
+        """
+        if not self.is_valid_position(row, column):
+            return None
+        for item in self.getPositionsLayout():
+            if api.to_int(item["row"]) == api.to_int(row):
+                if api.to_int(item["column"]) == api.to_int(column):
+                    return item
+        return None
+
+    def get_uid_at(self, row, column):
+        """Returns a uid this container contains at the given position.
+        """
+        item = self.get_item_at(row, column)
+        return item and item.get("uid", "") or None
+
+    def get_object_at(self, row, column):
+        """Returns an object this container contains at the given position
+        """
+        uid = self.get_uid_at(row, column)
+        if not api.is_uid(uid):
+            return None
+        return api.get_object_by_uid(uid, default=None)
+
+    def get_object_position(self, object_brain_uid):
+        """Returns the position as a tuple (row, column) of the object. If the
+        object is not found, returns None
+        """
+        uid = api.get_uid(object_brain_uid)
+        if not uid:
+            return None
+        els = filter(lambda el: el.get("uid", "") == uid,
+                     self.getPositionsLayout())
+        if not els:
+            return None
+        return (api.to_int(els[0]['row']), api.to_int(els[0]['column']))
+
+    def has_object(self, object_brain_uid):
+        """Returns if the container contains the object passed in
+        """
+        if self.get_object_position(object_brain_uid):
+            return True
+        return False
+
+    def is_object_allowed(self, object_brain_uid):
+        """Returns whether the type of object can be stored or not in this
+        container. This function returns true if the object is allowed, even
+        if the container already contains the object
+        """
+        raise NotImplementedError("Must be implemented by subclass")
+
+    def get_layout_containers(self):
+        """Returns the containers that belongs to this container and implement
+        IStorageLayoutContainer
+        """
+        return filter(lambda obj: IStorageLayoutContainer.providedBy(obj),
+                      self.objectValues())
+
+    def get_first_empty_position(self):
+        """Returns the first empty position of the layout as a tuple (row, col)
+        If there are no empty positions, returns None
+        """
+        available_positions = self.get_available_positions()
+        if not available_positions:
+            return None
+        return min(available_positions)
+
+    def get_minimum_size(self):
+        """Returns a tuple (rows, columns) that represents the minimum size this
+        container can have without removing any of the objects it contains
+        """
+        els = filter(self.is_taken, self.getPositionsLayout())
+        rows = map(lambda el: api.to_int(el['row']), els) or [0]
+        cols = map(lambda el: api.to_int(el['column']), els) or [0]
+        return (max(rows)+1, max(cols)+1)
+
+    def get_capacity(self):
+        """Returns the total number of positions available for this container
+        """
+        return self.getRows() * self.getColumns()
+
+    def is_full(self):
+        """Returns if the container is full. This is, there are no empty
+        positions remaining without an object in there
+        """
+        return not self.get_first_empty_position()
+
+    def remove_object(self, object_brain_uid, notify_parent=True):
+        """Removes the object from the container, if in there
+        """
+        uid = api.get_uid(object_brain_uid)
+        if not uid:
+            return False
+        els = filter(lambda el: el.get("uid", "") != uid,
+                     self.getPositionsLayout())
+        self.setPositionsLayout(els)
+
+        if notify_parent:
+            self.notify_parent()
+        return True
+
+    def notify_parent(self):
+        """Notifies the parent to update the information it holds about this
+        container
+        """
+        parent = api.get_parent(self)
+        if IStorageLayoutContainer.providedBy(parent):
+            parent.update_object(self)
+
+    def update_object(self, object_brain_uid):
+        """Updates the object from the container, if in there
+        """
+        position = self.get_object_position(object_brain_uid)
+        if not position:
+            return False
+        if not self.remove_object(object_brain_uid, notify_parent=False):
+            return False
+        return self.add_object_at(object_brain_uid, position[0], position[1])
+
+    def can_add_object(self, object_brain_uid, row, column):
+        """Returns whether the object can be added to the position
+        """
+        # Is the position valid?
+        if not self.is_valid_position(row, column):
+            logger.warn("Position ({}, {}) not valid for '{}'"
+                        .format(row, column, self.getId()))
+            return False
+
+        # Is a valid object or a valid uid?
+        uid = api.get_uid(object_brain_uid)
+        if not uid:
+            return False
+
+        # If position taken, the addition is not allowed
+        if self.get_uid_at(row, column):
+            logger.warn("Position ({}, {}) from '{}' is already taken"
+                        .format(row, column, self.getId()))
+            return False
+
+        # If the container already contains the object, do nothing
+        if self.has_object(object_brain_uid):
+            object_id = api.get_object(object_brain_uid).getId()
+            logger.warn("Container '{}' contains the object '{}' already"
+                        .format(self.getId(), object_id))
+            return False
+
+        # Check if this type of object suits well with this container
+        obj = api.get_object(object_brain_uid)
+        if not self.is_object_allowed(obj):
+            logger.warn("Container '{}' does not allow the object '{}'"
+                        .format(self.getId(), obj.getId()))
+            return False
+
+        return True
+
+    def add_object(self, object_brain_uid):
+        """Adds an object to the first available position.
+        """
+        position = self.get_first_empty_position()
+        if not position:
+            logger.warn("Cannot add object. No empty positions available")
+            return False
+        return self.add_object_at(object_brain_uid, position[0], position[1])
+
+    def add_object_at(self, object_brain_uid, row, column):
+        """Adds an object to the specified position. If an object already exists
+        at the given position, return False. Otherwise, return True
+        """
+        if not self.can_add_object(object_brain_uid, row, column):
+            return False
+
+        uid = api.get_uid(object_brain_uid)
+        obj = api.get_object(object_brain_uid)
+
+        # If the object does not implement StorageLayoutContainer, then we
+        # assume the object is not a container, rather the content that needs to
+        # be contained (e.g. a Sample), so we set capacity and utilization to 1
+        samples_capacity = 1
+        samples_utilization = 1
+        if IStorageLayoutContainer.providedBy(obj):
+            # This is a container, so infer the capacity and utilization
+            samples_capacity = obj.get_samples_capacity()
+            samples_utilization = obj.get_samples_utilization()
+
+        row = api.to_int(row)
+        column = api.to_int(column)
+        layout = [{
+            "uid": uid,
+            "row": row,
+            "column": column,
+            "samples_capacity": samples_capacity,
+            "samples_utilization": samples_utilization
+        }]
+        for item in self.getPositionsLayout():
+            if item["row"] == row and item["column"] == column:
+                continue
+            layout.append(item.copy())
+        self.setPositionsLayout(layout)
+        self.notify_parent()
+        return True
+
+    def get_layout_subfield_sum(self, subfield):
+        """Returns the sum of the elements stored in the layout for the subfield
+        name passed in. If the value for the element is not floatable, uses 0
+        """
+        layout = self.getPositionsLayout()
+        return sum(map(lambda el: api.to_int(el[subfield], default=0), layout))
+
+    def get_samples_capacity(self):
+        """Returns the total number of samples this container can store directly
+        or indirectly through contained containers
+        """
+        return self.get_layout_subfield_sum(subfield="samples_capacity")
+
+    def get_samples_utilization(self):
+        """Returns the total number of samples this container actually stores,
+        directly or indirectly through contained containers
+        """
+        return self.get_layout_subfield_sum(subfield="samples_utilization")
+
+    def is_samples_full(self):
+        """Returns whether if this container actually stores the maximum number
+        of samples allowed, directly or indirectly. Note that it will return
+        true if all containers this container contains are full of samples, even
+        if there are still free positions for new containers
+        """
+        return self.get_samples_capacity() == self.get_samples_utilization()
+
+    def reset_samples_usage(self, recursive=True):
+        """Resets the sample usage values (capacity and utilization) for this
+        container. It looks through all children to reset the values.
+        If recursive is set to True, the function reset the samples usage for
+        contained containers too.
+        """
+        items = filter(self.is_taken, self.getPositionsLayout())
+        items = map(lambda item: item.get["uid"], items)
+        uids = filter(api.is_uid, items)
+        if not uids:
+            return
+
+        query = dict(UID=uids)
+        uids_usage = {}
+        for brain in api.search(query, "uid_catalog"):
+            obj = api.get_object(brain)
+            if not IStorageLayoutContainer.providedBy(obj):
+                continue
+            if recursive:
+                obj.reset_samples_usage(recursive=recursive)
+            uids_usage[api.get_uid(obj)] = {
+                "samples_utilization": obj.get_samples_utilization(),
+                "samples_capacity": obj.get_samples_capacity(),
+            }
+
+        new_items = list()
+        for layout_item in self.getPositionsLayout():
+            item = layout_item.copy()
+            usage = uids_usage.get(item.get("uid"), None)
+            if usage:
+                item.update(usage)
+            new_items.append(item)
+        self.setPositionsLayout(new_items)

--- a/src/senaite/storage/profiles/default/factorytool.xml
+++ b/src/senaite/storage/profiles/default/factorytool.xml
@@ -11,7 +11,6 @@
 -->
 <object name="portal_factory" meta_type="Plone Factory Tool">
   <factorytypes>
-    <type portal_type="StorageContainer"/>
     <type portal_type="StorageRootFolder"/>
     <type portal_type="StorageSamplesContainer"/>
   </factorytypes>

--- a/src/senaite/storage/profiles/default/metadata.xml
+++ b/src/senaite/storage/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>2701</version>
+  <version>2702</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/senaite/storage/profiles/default/types.xml
+++ b/src/senaite/storage/profiles/default/types.xml
@@ -12,9 +12,9 @@
 -->
 <object name="portal_types">
   <object name="StorageRootFolder" meta_type="Factory-based Type Information with dynamic views"/>
-  <object name="StorageContainer" meta_type="Factory-based Type Information with dynamic views"/>
   <object name="StorageSamplesContainer" meta_type="Factory-based Type Information with dynamic views"/>
 
   <object name="StorageFacility" meta_type="Dexterity FTI" />
   <object name="StoragePosition" meta_type="Dexterity FTI" />
+  <object name="StorageContainer" meta_type="Dexterity FTI"/>
 </object>

--- a/src/senaite/storage/profiles/default/types/StorageContainer.xml
+++ b/src/senaite/storage/profiles/default/types/StorageContainer.xml
@@ -1,51 +1,90 @@
-<?xml version="1.0"?>
-<object name="StorageContainer"
-        meta_type="Factory-based Type Information with dynamic views"
+<object name="StorageContainer" meta_type="Dexterity FTI"
         i18n:domain="senaite.storage"
-        xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-        purge="True">
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n">
 
-  <!-- Basic metadata -->
-  <property name="title" i18n:translate="">Storage container</property>
+  <!-- Title and Description -->
+  <property name="title"
+            i18n:translate="">Storage Container</property>
+  <property name="description"
+            i18n:translate=""></property>
+
+  <!-- content-type icon -->
   <property name="icon_expr">senaite_theme/icon/storage-container</property>
-  <property name="content_meta_type">StorageContainer</property>
-  <property name="product">senaite.storage</property>
-  <property name="factory">addStorageContainer</property>
-  <property name="global_allow">False</property>
+
+  <!-- factory name; usually the same as type name -->
+  <property name="factory">StorageContainer</property>
+
+  <!-- URL TALES expression to add an item TTW -->
+  <property name="add_view_expr">
+    string:${folder_url}/++add++StorageContainer
+  </property>
+
+  <property name="link_target"/>
+  <property name="immediate_view">view</property>
+
+  <!-- Is this item addable globally, or is it restricted? -->
+  <property name="global_allow">True</property>
+
+  <!-- If we're a container, should we filter addable content types? -->
   <property name="filter_content_types">True</property>
+  <!-- If filtering, what's allowed -->
   <property name="allowed_content_types">
     <element value="StorageSamplesContainer"/>
     <element value="StorageContainer"/>
   </property>
+
   <property name="allow_discussion">False</property>
 
-  <!-- View information -->
+  <!-- what are our available view methods, and what's the default? -->
+  <property name="default_view">view</property>
+  <!-- the view methods below will be selectable via the display tab -->
+  <property name="view_methods">
+    <element value="view"/>
+  </property>
   <property name="default_view_fallback">False</property>
 
-  <!-- Method aliases -->
-  <alias from="(Default)" to="view"/>
-  <alias from="edit" to="base_edit"/>
-  <alias from="view" to="view"/>
+  <!-- permission required to add an item of this type -->
+  <property name="add_permission">cmf.AddPortalContent</property>
 
-  <!-- Actions -->
+  <!-- Python class for content items of this sort -->
+  <property name="schema">senaite.storage.content.storage_container.IStorageContainerSchema</property>
+  <property name="klass">senaite.storage.content.storage_container.StorageContainer</property>
+
+  <!-- Dexterity behaviours for this type -->
+  <property name="behaviors">
+    <element value="bika.lims.interfaces.IAutoGenerateID"/>
+    <element value="bika.lims.interfaces.IMultiCatalogBehavior"/>
+    <element value="plone.app.referenceablebehavior.referenceable.IReferenceable" />
+  </property>
+
+  <!-- Action aliases -->
+  <alias from="(Default)" to="(dynamic view)"/>
+  <alias from="edit" to="@@edit"/>
+  <alias from="sharing" to="@@sharing"/>
+  <alias from="view" to="(selected layout)"/>
+
+  <!-- View -->
   <action title="View"
           action_id="view"
           category="object"
           condition_expr=""
+          description=""
+          icon_expr=""
+          link_target=""
           url_expr="string:${object_url}"
-          i18n:attributes="title"
-          i18n:domain="plone"
           visible="True">
     <permission value="View"/>
   </action>
 
+  <!-- Edit -->
   <action title="Edit"
           action_id="edit"
           category="object"
           condition_expr=""
+          description=""
+          icon_expr=""
+          link_target=""
           url_expr="string:${object_url}/edit"
-          i18n:attributes="title"
-          i18n:domain="plone"
           visible="True">
     <permission value="Modify portal content"/>
   </action>

--- a/src/senaite/storage/upgrade/v02_07_000.py
+++ b/src/senaite/storage/upgrade/v02_07_000.py
@@ -28,6 +28,7 @@ from senaite.core.upgrade import upgradestep
 from senaite.core.upgrade.utils import UpgradeUtils
 from senaite.storage import PRODUCT_NAME
 from senaite.storage import logger
+from senaite.storage.catalog import STORAGE_CATALOG
 from zope.component import getMultiAdapter
 
 version = "2.7.0"
@@ -35,6 +36,7 @@ profile = "profile-{0}:default".format(PRODUCT_NAME)
 
 REMOVE_AT_TYPES = [
     "StorageFacility",
+    "StorageContainer",
 ]
 
 
@@ -132,6 +134,89 @@ def migrate_storage_facility_to_dx(src, destination):
     address = dict(src.getAddress())
     address["type"] = PHYSICAL_ADDRESS
     target.setAddress(address)
+
+    cb = src.manage_copyObjects(ids=src.objectIds())
+    target.manage_pasteObjects(cb)
+
+    # Migrate the contents from AT to DX
+    migrator = getMultiAdapter(
+        (src, target), interface=IContentMigrator)
+
+    # copy all (raw) attributes from the source object to the target
+    migrator.copy_attributes(src, target)
+
+    # copy the UID
+    migrator.copy_uid(src, target)
+
+    # copy auditlog
+    migrator.copy_snapshots(src, target)
+
+    # copy creators
+    migrator.copy_creators(src, target)
+
+    # copy workflow history
+    migrator.copy_workflow_history(src, target)
+
+    # copy marker interfaces
+    migrator.copy_marker_interfaces(src, target)
+
+    # copy dates
+    migrator.copy_dates(src, target)
+
+    # uncatalog the source object
+    migrator.uncatalog_object(src)
+
+    # delete the old object
+    migrator.delete_object(src)
+
+    # change the ID *after* the original object was removed
+    migrator.copy_id(src, target)
+
+
+def migrate_storage_containers_to_dx(tool):
+    """Converts existing storage containers to DX
+    """
+    logger.info("Convert Storage Containers to Dexterity ...")
+
+    # ensure old AT types are flushed first
+    remove_at_portal_types(tool)
+
+    # run required import steps
+    tool.runImportStepFromProfile(profile, "typeinfo")
+    tool.runImportStepFromProfile(profile, "workflow")
+
+    query = {
+        "portal_type": "StorageContainer",
+    }
+    results = api.search(query, STORAGE_CATALOG)
+
+    for brain in results:
+        obj = api.get_object(brain)
+        if not api.is_at_content(obj):
+            continue
+        logger.info("Migrating storage container '%s'" % obj.Title())
+        destination = api.get_parent(obj)
+        migrate_storage_container_to_dx(obj, destination)
+        logger.info("Migrating storage container '%s' [DONE]" % obj.Title())
+
+    logger.info("Convert Storage Containers to Dexterity [DONE]")
+
+
+def migrate_storage_container_to_dx(src, destination):
+    """Migrate a single storage facility
+    """
+    target_id = tmpID()
+    portal_type = "StorageContainer"
+
+    # cretate the new facility
+    target = createContent(portal_type, id=target_id)
+    destination._setObject(target_id, target)
+    target = destination._getOb(target_id)
+
+    # Manually set the fields
+    # NOTE: always convert string values to unicode for dexterity fields!
+    target.title = api.safe_unicode(src.Title() or "")
+    target.temperature = src.getTemperature() or 0.0
 
     cb = src.manage_copyObjects(ids=src.objectIds())
     target.manage_pasteObjects(cb)

--- a/src/senaite/storage/upgrade/v02_07_000.zcml
+++ b/src/senaite/storage/upgrade/v02_07_000.zcml
@@ -3,6 +3,14 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="SENAITE.STORAGE 2.7.0: Migrate Storage Containers to DX"
+      description="Migrate all AT Storage Containers to Dexterity"
+      source="2701"
+      destination="2702"
+      handler=".v02_07_000.migrate_storage_containers_to_dx"
+      profile="senaite.storage:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.STORAGE 2.7.0: Migrate Storage Facilities to DX"
       description="Migrate all AT Storage Facilities to Dexterity"
       source="2700"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR migrates `StorageLayoutContainer` and `StorageContainer` to Dexterity.

## Current behavior before PR

- AT based `StorageLayoutContainer` and `StorageContainer` 

## Desired behavior after PR is merged

- DX based `StorageLayoutContainer` and `StorageContainer` 


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
