### PR TITLE
Fix AttributeError for containers with more than 25 rows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #53 Fix AttributeError for containers with more than 25 rows
 - #52 Migrate Storage Root Folder to DX
 - #51 JS->DX compatibility
 - #50 Migrate storage samples container to DX

--- a/src/senaite/storage/content/storage_layout_container.py
+++ b/src/senaite/storage/content/storage_layout_container.py
@@ -215,10 +215,21 @@ class StorageLayoutContainer(Container):
         """Returns the alpha part for the passed in row
         """
         alphabet = string.ascii_uppercase
-        num, idx = divmod(int(row), len(alphabet))
-        if num:
-            return self.get_alpha_column(num - 1) + alphabet[idx]
-        return alphabet[idx]
+        def alpha(num):
+            """Converts the given number to alphabetical letter(s).
+            alpha(1) == 'A'
+            alpha(26) == 'Z'
+            alpha(27) == 'AA'
+            alpha(28) == 'AB'
+            """
+            if num == 0:
+                return ""
+            prefix = alpha((num - 1) // len(alphabet))
+            letter = chr((num - 1) % len(alphabet) + ord(alphabet[0]))
+            return "%s%s" % (prefix, letter)
+
+        # row is a position, starting from 0, so we need to add 1
+        return alpha(row + 1)
 
     def position_to_alpha(self, row, column):
         """Returns a position in alphanumeric format (e.g A01)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes an error that arises when resolving the letters that correspond to a given row and the position of the row is equal or greater than alphabet's length (26). For instance, this happens when trying to render a layout for a sample container with 50 rows and 1 column:

<img width="569" height="487" alt="20250804192008" src="https://github.com/user-attachments/assets/1f39412d-ae63-4ba9-b7bc-eeba41a745ef" />

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.CMFPlone.controlpanel.browser.quickinstaller, line 666, in __call__
  Module Products.CMFPlone.controlpanel.browser.quickinstaller, line 399, in upgrade_product
  Module Products.GenericSetup.tool, line 1202, in upgradeProfile
  Module Products.GenericSetup.upgrade, line 185, in doStep
  Module senaite.storage.upgrade.v02_07_000, line 381, in migrate_storage_root_folder_to_dx
  Module OFS.CopySupport, line 326, in manage_pasteObjects
  Module OFS.CopySupport, line 237, in _pasteObjects
  Module Products.BTreeFolder2.BTreeFolder2, line 469, in _setObject
  Module zope.event, line 33, in notify
  Module zope.component.event, line 27, in dispatch
  Module zope.component._api, line 134, in subscribers
  Module zope.interface.registry, line 448, in subscribers
  Module zope.interface.adapter, line 899, in subscribers
  Module zope.component.event, line 36, in objectEventNotify
  Module zope.component._api, line 134, in subscribers
  Module zope.interface.registry, line 448, in subscribers
  Module zope.interface.adapter, line 899, in subscribers
  Module OFS.subscribers, line 116, in dispatchObjectMovedEvent
  Module zope.container.contained, line 157, in dispatchToSublocations
  Module zope.component._api, line 138, in handle
  Module zope.interface.registry, line 448, in subscribers
  Module zope.interface.adapter, line 899, in subscribers
  Module OFS.subscribers, line 116, in dispatchObjectMovedEvent
  Module zope.container.contained, line 157, in dispatchToSublocations
  Module zope.component._api, line 138, in handle
  Module zope.interface.registry, line 448, in subscribers
  Module zope.interface.adapter, line 899, in subscribers
  Module senaite.storage.subscribers, line 29, in StorageContentAddedEventHandler
  Module senaite.storage.content.storage_layout_container, line 265, in rebuild_layout
  Module senaite.storage.content.storage_layout_container, line 264, in <lambda>
  Module senaite.storage.content.storage_layout_container, line 226, in position_to_alpha
  Module senaite.storage.content.storage_layout_container, line 220, in get_alpha_row
AttributeError: 'RequestContainer' object has no attribute 'get_alpha_column'
```

## Desired behavior after PR is merged

No error, rows beyond `Z` are rendered in Layout view:

<img width="166" height="359" alt="20250804192143" src="https://github.com/user-attachments/assets/60924510-e88a-4d97-9956-fd99ce85bfaa" />


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
