### PR TITLE
Fix all storage containers reindexed when other add-ons are upgraded

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #54 Fix all storage containers reindexed when other add-ons are upgraded
 - #53 Fix AttributeError for containers with more than 25 rows
 - #52 Migrate Storage Root Folder to DX
 - #51 JS->DX compatibility

--- a/src/senaite/storage/subscribers/upgrade.py
+++ b/src/senaite/storage/subscribers/upgrade.py
@@ -18,9 +18,12 @@
 # Copyright 2019-2024 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from bika.lims.api import get_portal
 from senaite.storage import is_installed
 from senaite.storage import logger
-from senaite.storage.setuphandlers import post_install
+from senaite.storage import PRODUCT_NAME
+from senaite.storage.setuphandlers import setup_catalogs
+from senaite.storage.setuphandlers import setup_workflows
 
 
 def afterUpgradeStepHandler(event):
@@ -28,7 +31,20 @@ def afterUpgradeStepHandler(event):
     """
     if not is_installed():
         return
-    logger.info("Run senaite.storage.afterUpgradeStepHandler ...")
-    setup = event.context
-    post_install(setup)
-    logger.info("Run senaite.storage.afterUpgradeStepHandler [DONE]")
+
+    logger.info("Run {}.afterUpgradeStepHandler ...".format(PRODUCT_NAME))
+    portal = get_portal()
+    setup = portal.portal_setup  # noqa
+
+    profile = "profile-{0}:default".format(PRODUCT_NAME)
+    setup.runImportStepFromProfile(profile, "typeinfo")
+    setup.runImportStepFromProfile(profile, "rolemap")
+    setup.runImportStepFromProfile(profile, "workflow")
+
+    # Setup catalogs
+    setup_catalogs(portal)
+
+    # Setup workflows
+    setup_workflows(portal)
+
+    logger.info("Run {}.afterUpgradeStepHandler [DONE]".format(PRODUCT_NAME))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request optimizes the upgrade process to ensure that only the required import steps are executed when other add-ons are upgraded.

## Current behavior before PR

Upgrading another add-on triggers a reindexing of all sample storage containers, even when unnecessary.

## Desired behavior after PR is merged

Upgrading another add-on runs only the necessary import steps, preventing redundant reindexing.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
