### PR TITLE
Fix Unauthorized error when moving a container across storage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #55 Fix Unauthorized error when moving a container across storage
 - #54 Fix all storage containers reindexed when other add-ons are upgraded
 - #53 Fix AttributeError for containers with more than 25 rows
 - #52 Migrate Storage Root Folder to DX

--- a/src/senaite/storage/browser/container/move_container.py
+++ b/src/senaite/storage/browser/container/move_container.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 from bika.lims import api
+from bika.lims.api import security
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from senaite.storage import logger
 from senaite.storage import senaiteMessageFactory as _
@@ -28,6 +29,7 @@ from senaite.storage.catalog import STORAGE_CATALOG
 from senaite.storage.interfaces import IStorageContainer
 from senaite.storage.interfaces import IStorageFacility
 from senaite.storage.interfaces import IStorageSamplesContainer
+from senaite.storage.permissions import TransitionMoveContainer
 
 
 class MoveContainerView(BaseView):
@@ -91,16 +93,23 @@ class MoveContainerView(BaseView):
         """move container from source to destination
         """
         source = api.get_object(src)
+
+        # check if current user can perform the transition
+        if not security.check_permission(TransitionMoveContainer, source):
+            message = _(u"You do not have permission to move this container.")
+            self.add_status_message(message, level="error")
+            return False
+
         destination = api.get_object(dest)
         parent = api.get_parent(source)
-
         if destination == parent:
             message = _(u"Container {} is already located in destination path!"
                         .format(self.get_container_path(source)))
             self.add_status_message(message, level="warning")
             return False
-        cb = parent.manage_cutObjects(ids=[api.get_id(source)])
-        destination.manage_pasteObjects(cb_copy_data=cb)
+
+        # move w/o permission check (better than granting "Delete" wide)
+        api.move_object(source, destination, check_constraints=False)
 
         message = _(u"Moved container {} → {}".format(
             self.get_title(source), self.get_container_path(destination)))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request allows to move a container or sample container from one place to another within storage. It also checks that the current user has enough privileges to move the object across.

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module senaite.storage.browser.container.move_container, line 63, in __call__
  Module senaite.storage.browser.container.move_container, line 103, in move_container
  Module OFS.CopySupport, line 326, in manage_pasteObjects
  Module OFS.CopySupport, line 211, in _pasteObjects
  Module plone.dexterity.content, line 273, in _verifyObjectPaste
  Module Products.CMFCore.PortalFolder, line 400, in _verifyObjectPaste
  Module OFS.CopySupport, line 517, in _verifyObjectPaste
Unauthorized: Delete not allowed.
```

## Desired behavior after PR is merged

No error message is displayed and the container is moved to destination

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
