### PR TITLE
Fix UnicodeDecodeError on positions display in storage listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #56 Fix UnicodeDecodeError on positions display in storage listing
 - #55 Fix Unauthorized error when moving a container across storage
 - #54 Fix all storage containers reindexed when other add-ons are upgraded
 - #53 Fix AttributeError for containers with more than 25 rows

--- a/src/senaite/storage/browser/facility/view.py
+++ b/src/senaite/storage/browser/facility/view.py
@@ -118,6 +118,6 @@ class FacilityListingView(StorageListing):
         obj = api.get_object(obj)
         parents = get_parents(
             obj, predicate=lambda o: IStorageFacility.providedBy(o))
-        item["replace"]["Position"] = " » ".join(
+        item["replace"]["Position"] = " &raquo; ".join(
             map(get_link_for, reversed(parents)))
         return item


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes an error that occurs when rendering the positions list of sample containers within a storage facility.

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module senaite.app.listing.view, line 246, in __call__
  Module senaite.app.listing.ajax, line 112, in handle_subpath
  Module senaite.core.decorators, line 40, in decorator
  Module senaite.app.listing.decorators, line 63, in wrapper
  Module senaite.app.listing.decorators, line 50, in wrapper
  Module senaite.app.listing.decorators, line 100, in wrapper
  Module senaite.app.listing.ajax, line 379, in ajax_folderitems
  Module senaite.app.listing.decorators, line 88, in wrapper
  Module senaite.app.listing.ajax, line 258, in get_folderitems
  Module senaite.app.listing.view, line 982, in folderitems
  Module senaite.storage.browser.facility.view, line 122, in folderitem
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 1: ordinal not in range(128)
```

## Desired behavior after PR is merged

Listing is rendered without errors

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
