### PR TITLE
Compatibility with core#2835 (display Storage in navbar)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #57 Compatibility with core#2835 (display Storage in navbar)
 - #56 Fix UnicodeDecodeError on positions display in storage listing
 - #55 Fix Unauthorized error when moving a container across storage
 - #54 Fix all storage containers reindexed when other add-ons are upgraded

--- a/src/senaite/storage/profiles/default/metadata.xml
+++ b/src/senaite/storage/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>2704</version>
+  <version>2705</version>
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>
     <dependency>profile-senaite.lims:default</dependency>

--- a/src/senaite/storage/setuphandlers.py
+++ b/src/senaite/storage/setuphandlers.py
@@ -20,7 +20,6 @@
 
 from Acquisition import aq_base
 from bika.lims import api
-from plone.registry.interfaces import IRegistry
 from Products.CMFCore.permissions import ModifyPortalContent
 from Products.DCWorkflow.Guard import Guard
 from senaite.core import permissions
@@ -34,7 +33,6 @@ from senaite.storage.catalog import STORAGE_CATALOG
 from senaite.storage.catalog import StorageCatalog
 from senaite.storage.config import PRODUCT_NAME
 from senaite.storage.config import PROFILE_ID
-from zope.component import getUtility
 
 SITE_STRUCTURE = [
     # Tuples of (portal_type, obj_id, obj_title, parent_path, display_type)
@@ -433,20 +431,12 @@ def display_in_nav(obj):
     """
     portal_type = api.get_portal_type(obj)
 
-    # add to the plone's registry displayed_types
-    registry = getUtility(IRegistry)
-    key = "plone.displayed_types"
-    displayed = registry.get(key, ())
-    if portal_type not in displayed:
-        displayed += (portal_type,)
-        registry[key] = displayed
-
-    # add to senaite setup's sidebar_displayed_types
+    # remove from senaite setup's sidebar_skip_types
     setup = api.get_senaite_setup()
-    displayed = setup.getSidebarDisplayedTypes()
-    if displayed and portal_type not in displayed:
-        displayed += (portal_type,)
-        setup.setSidebarDisplayedTypes(displayed)
+    skip = setup.getSidebarSkipTypes()
+    if skip and portal_type in skip:
+        skip = tuple(pt for pt in skip if pt != portal_type)
+        setup.setSidebarSkipTypes(skip)
 
     # if a root folder, add to senaite setup's sidebar_folders
     setup = api.get_senaite_setup()
@@ -457,7 +447,6 @@ def display_in_nav(obj):
         if obj_id not in folders:
             folders += (obj_id, )
             setup.setSidebarFolders(folders)
-
 
 def reindex_storage_structure(portal):
     """Reindex storage structure

--- a/src/senaite/storage/setuphandlers.py
+++ b/src/senaite/storage/setuphandlers.py
@@ -20,8 +20,7 @@
 
 from Acquisition import aq_base
 from bika.lims import api
-from plone import api as ploneapi
-from plone.app.dexterity.behaviors.exclfromnav import IExcludeFromNavigation
+from plone.registry.interfaces import IRegistry
 from Products.CMFCore.permissions import ModifyPortalContent
 from Products.DCWorkflow.Guard import Guard
 from senaite.core import permissions
@@ -35,7 +34,7 @@ from senaite.storage.catalog import STORAGE_CATALOG
 from senaite.storage.catalog import StorageCatalog
 from senaite.storage.config import PRODUCT_NAME
 from senaite.storage.config import PROFILE_ID
-
+from zope.component import getUtility
 
 SITE_STRUCTURE = [
     # Tuples of (portal_type, obj_id, obj_title, parent_path, display_type)
@@ -429,20 +428,35 @@ def setup_site_structure(portal):
 
 
 def display_in_nav(obj):
-    """Makes an object to be displayed in the navigation bar
+    """Makes an object and/or objects from the given portal type to be
+    displayed in the navigation bar
     """
-    # Display in navigation
-    registry_id = "plone.displayed_types"
     portal_type = api.get_portal_type(obj)
-    to_display = ploneapi.portal.get_registry_record(registry_id, default=())
-    if portal_type not in to_display:
-        to_display = to_display + (portal_type, )
-        ploneapi.portal.set_registry_record(registry_id, to_display)
 
-    nav_exclude = IExcludeFromNavigation(obj, None)
-    if nav_exclude:
-        nav_exclude.exclude_from_nav = False
-        obj.reindexObject(idxs=["exclude_from_nav"])
+    # add to the plone's registry displayed_types
+    registry = getUtility(IRegistry)
+    key = "plone.displayed_types"
+    displayed = registry.get(key, ())
+    if portal_type not in displayed:
+        displayed += (portal_type,)
+        registry[key] = displayed
+
+    # add to senaite setup's sidebar_displayed_types
+    setup = api.get_senaite_setup()
+    displayed = setup.getSidebarDisplayedTypes()
+    if displayed and portal_type not in displayed:
+        displayed += (portal_type,)
+        setup.setSidebarDisplayedTypes(displayed)
+
+    # if a root folder, add to senaite setup's sidebar_folders
+    setup = api.get_senaite_setup()
+    portal = api.get_portal()
+    if api.get_parent(obj) == portal:
+        obj_id = api.get_id(obj)
+        folders = setup.getSidebarFolders()
+        if obj_id not in folders:
+            folders += (obj_id, )
+            setup.setSidebarFolders(folders)
 
 
 def reindex_storage_structure(portal):

--- a/src/senaite/storage/tests/base.py
+++ b/src/senaite/storage/tests/base.py
@@ -19,88 +19,42 @@
 # Some rights reserved, see README and LICENSE.
 
 import transaction
-import unittest2 as unittest
-from plone.app.testing import PLONE_FIXTURE
-from plone.app.testing import TEST_USER_ID
-from plone.app.testing import FunctionalTesting
-from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import applyProfile
-from plone.app.testing import setRoles
+from plone.app.testing import FunctionalTesting
 from plone.testing import zope
+from senaite.core.tests.base import BaseTestCase
+from senaite.core.tests.layers import BaseLayer
 
 
-class SimpleTestLayer(PloneSandboxLayer):
-    """Setup Plone with installed AddOn only
-    """
-    defaultBases = (PLONE_FIXTURE,)
+class SimpleTestLayer(BaseLayer):
 
     def setUpZope(self, app, configurationContext):
         super(SimpleTestLayer, self).setUpZope(app, configurationContext)
 
-        import bika.lims
-        import senaite.app.listing
-        import senaite.app.spotlight
-        import senaite.core
-        import senaite.impress
-        import senaite.lims
-        import senaite.storage
-
         # Load ZCML
-        self.loadZCML(package=bika.lims)
-        self.loadZCML(package=senaite.lims)
-        self.loadZCML(package=senaite.core)
-        self.loadZCML(package=senaite.app.listing)
-        self.loadZCML(package=senaite.impress)
-        self.loadZCML(package=senaite.app.spotlight)
+        import senaite.storage
         self.loadZCML(package=senaite.storage)
 
         # Install product and call its initialize() function
-        zope.installProduct(app, "bika.lims")
-        zope.installProduct(app, "senaite.lims")
-        zope.installProduct(app, "senaite.core")
-        zope.installProduct(app, "senaite.app.listing")
-        zope.installProduct(app, "senaite.impress")
-        zope.installProduct(app, "senaite.app.spotlight")
         zope.installProduct(app, "senaite.storage")
 
     def setUpPloneSite(self, portal):
         super(SimpleTestLayer, self).setUpPloneSite(portal)
-        applyProfile(portal, "senaite.core:default")
         applyProfile(portal, "senaite.storage:default")
         transaction.commit()
 
 
-###
-# Use for simple tests (w/o contents)
-###
-SIMPLE_FIXTURE = SimpleTestLayer()
+SIMPLE_TEST_LAYER_FIXTURE = SimpleTestLayer()
 SIMPLE_TESTING = FunctionalTesting(
-    bases=(SIMPLE_FIXTURE, ),
+    bases=(SIMPLE_TEST_LAYER_FIXTURE,),
     name="senaite.storage:SimpleTesting"
 )
 
 
-class SimpleTestCase(unittest.TestCase):
+class SimpleTestCase(BaseTestCase):
+    """Use for test cases which do not rely on demo data
+    """
     layer = SIMPLE_TESTING
 
     def setUp(self):
         super(SimpleTestCase, self).setUp()
-
-        self.app = self.layer["app"]
-        self.portal = self.layer["portal"]
-        self.request = self.layer["request"]
-        self.request["ACTUAL_URL"] = self.portal.absolute_url()
-        setRoles(self.portal, TEST_USER_ID, ["LabManager", "Manager"])
-
-
-class FunctionalTestCase(unittest.TestCase):
-    layer = SIMPLE_TESTING
-
-    def setUp(self):
-        super(FunctionalTestCase, self).setUp()
-
-        self.app = self.layer["app"]
-        self.portal = self.layer["portal"]
-        self.request = self.layer["request"]
-        self.request["ACTUAL_URL"] = self.portal.absolute_url()
-        setRoles(self.portal, TEST_USER_ID, ["LabManager", "Member"])

--- a/src/senaite/storage/tests/doctests/StorageNavigation.rst
+++ b/src/senaite/storage/tests/doctests/StorageNavigation.rst
@@ -1,0 +1,79 @@
+Storage Navigation Bar Visibility
+==================================
+
+This test ensures that the Storage folder is visible in the navigation bar
+after installation, in accordance with the new sidebar navigation system
+introduced in senaite.core.
+
+Running this test from the buildout directory:
+
+    bin/test -m senaite.storage -t StorageNavigation
+
+
+Test Setup
+..........
+
+Needed Imports:
+
+    >>> from bika.lims import api
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> setup = api.get_senaite_setup()
+    >>> storage = portal.senaite_storage
+
+Assign default roles for the user to test with:
+
+    >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
+
+
+Storage Folder Navigation Visibility
+-------------------------------------
+
+After installation, the Storage folder should be visible in the navigation bar.
+This is configured through two mechanisms:
+
+1. The portal type "StorageRootFolder" should NOT be in SENAITE Setup's sidebar_skip_types
+   (types in this list are excluded from the sidebar):
+
+    >>> sidebar_skip_types = setup.getSidebarSkipTypes()
+    >>> sidebar_skip_types is not None
+    True
+    >>> "StorageRootFolder" not in sidebar_skip_types
+    True
+
+2. Since the storage folder is a root folder (direct child of portal), its ID
+   should be in SENAITE Setup's sidebar_folders:
+
+    >>> sidebar_folders = setup.getSidebarFolders()
+    >>> sidebar_folders is not None
+    True
+    >>> "senaite_storage" in sidebar_folders
+    True
+
+
+Verify Storage Folder Properties
+---------------------------------
+
+The storage folder should exist and be properly configured:
+
+    >>> storage is not None
+    True
+
+    >>> api.get_portal_type(storage)
+    'StorageRootFolder'
+
+    >>> api.get_id(storage)
+    'senaite_storage'
+
+    >>> storage.Title()
+    'Sample storage'
+
+The storage folder should be a direct child of the portal:
+
+    >>> api.get_parent(storage) == portal
+    True

--- a/src/senaite/storage/tests/test_doctests.py
+++ b/src/senaite/storage/tests/test_doctests.py
@@ -21,29 +21,33 @@
 import doctest
 from os.path import join
 
-from pkg_resources import resource_listdir
-
 import unittest2 as unittest
-from senaite.storage.config import PRODUCT_NAME
+from pkg_resources import resource_listdir
+from senaite.storage import PRODUCT_NAME
 from senaite.storage.tests.base import SimpleTestCase
 from Testing import ZopeTestCase as ztc
 
-rst_filenames = [f for f in resource_listdir(PRODUCT_NAME, "tests/doctests")
-                 if f.endswith(".rst")]
-
-doctests = [join("doctests", filename) for filename in rst_filenames]
-
+# Option flags for doctests
 flags = doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE | doctest.REPORT_NDIFF
 
 
 def test_suite():
     suite = unittest.TestSuite()
-    for doctestfile in doctests:
+    for doctest_file in get_doctest_files():
         suite.addTests([
             ztc.ZopeDocFileSuite(
-                doctestfile,
+                doctest_file,
                 test_class=SimpleTestCase,
                 optionflags=flags
             )
         ])
     return suite
+
+
+def get_doctest_files():
+    """
+    Return the available doctest files for this package.
+    """
+    files = resource_listdir(PRODUCT_NAME, "tests/doctests")
+    files = filter(lambda name: name.endswith(".rst"), files)
+    return map(lambda name: join("doctests", name), files)

--- a/src/senaite/storage/upgrade/v02_07_000.py
+++ b/src/senaite/storage/upgrade/v02_07_000.py
@@ -29,6 +29,7 @@ from senaite.core.upgrade.utils import UpgradeUtils
 from senaite.storage import PRODUCT_NAME
 from senaite.storage import logger
 from senaite.storage.catalog import STORAGE_CATALOG
+from senaite.storage.setuphandlers import display_in_nav
 from zope.component import getMultiAdapter
 
 version = "2.7.0"
@@ -415,3 +416,12 @@ def migrate_storage_root_folder_to_dx(tool):
     migrator.copy_id(src, target)
 
     logger.info("Convert Storage Root Folder to Dexterity [DONE]")
+
+
+def display_storage_navbar(tool):
+    """Displays the storage's root folder in the navigation bar
+    """
+    logger.info("Display storage in navigation bar ...")
+    portal = api.get_portal()
+    display_in_nav(portal.senaite_storage)
+    logger.info("Display storage in navigation bar [DONE]")

--- a/src/senaite/storage/upgrade/v02_07_000.zcml
+++ b/src/senaite/storage/upgrade/v02_07_000.zcml
@@ -3,6 +3,18 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="Display Storage in navigation bar"
+      description="
+        This upgrade step makes the product compatible with senaite.core#2835
+        by adding the Storage folder to the setup field “Sidebar displayed
+        portal types”, thereby displaying the Storage link in the left-hand
+        navigation bar."
+      source="2704"
+      destination="2705"
+      handler=".v02_07_000.display_storage_navbar"
+      profile="senaite.storage:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.STORAGE 2.7.0: Migrate Storage Root Folder to DX"
       description="Migrate the Storage Root Folder to Dexterity"
       source="2703"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

> [!IMPORTANT]
> Requires:
> - https://github.com/senaite/senaite.core/pull/2835

This Pull Request makes this product compatible with https://github.com/senaite/senaite.core/pull/2835

## Current behavior before PR

Storage folder is not visible in the navigation bar after core's upgrade 2718

## Desired behavior after PR is merged

Storage folder is visible in the navigation bar after core's upgrade 2718

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
