### PR TITLE
Fix AttributeError when migrating facilities to DX (2701)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #59 Fix AttributeError when migrating facilities to DX (2701)
 - #56 Fix UnicodeDecodeError on positions display in storage listing
 - #55 Fix Unauthorized error when moving a container across storage
 - #54 Fix all storage containers reindexed when other add-ons are upgraded

--- a/src/senaite/storage/content/storage_facility.py
+++ b/src/senaite/storage/content/storage_facility.py
@@ -162,7 +162,7 @@ class StorageFacility(Container):
     @security.protected(permissions.View)
     def getAddress(self):
         accessor = self.accessor("address")
-        return accessor(self) or ""
+        return accessor(self)
 
     @security.protected(permissions.ModifyPortalContent)
     def setAddress(self, value):

--- a/src/senaite/storage/content/storage_facility.py
+++ b/src/senaite/storage/content/storage_facility.py
@@ -167,7 +167,7 @@ class StorageFacility(Container):
     @security.protected(permissions.ModifyPortalContent)
     def setAddress(self, value):
         mutator = self.mutator("address")
-        mutator(self, api.safe_unicode(value))
+        mutator(self, value)
 
     # BBB: AT schema field property
     Address = property(getAddress, setAddress)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Fixes `AttributeError: 'unicode' object has no attribute 'get'` during AT to DX migration of storage facilities (upgrade step 2701). The `StorageFacility.setAddress()` function was incorrectly converting the address dictionary to `unicode` before passing it to the `AddressField` mutator, which expects a `dict` or list of `dict`s, causing the migration to fail when trying to set the address field on the new Dexterity object.

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.CMFPlone.controlpanel.browser.quickinstaller, line 666, in __call__
  Module Products.CMFPlone.controlpanel.browser.quickinstaller, line 399, in upgrade_product
  Module Products.GenericSetup.tool, line 1202, in upgradeProfile
  Module Products.GenericSetup.upgrade, line 185, in doStep
  Module senaite.storage.upgrade.v02_07_000, line 113, in migrate_storage_facilities_to_dx
  Module senaite.storage.upgrade.v02_07_000, line 138, in migrate_storage_facility_to_dx
  Module senaite.storage.content.storage_facility, line 170, in setAddress
  Module senaite.core.schema.addressfield, line 85, in set
AttributeError: 'unicode' object has no attribute 'get'
```

## Desired behavior after PR is merged

Upgrade step 2701 finishes without error and storage facilities have the address properly set

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
