### PR TITLE
Fix sample search when assigning received samples to storage container

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #60 Fix sample search when assigning received samples to storage container
 - #58 Fix ValueError: undefined property 'add_permission' on upgrade
 - #57 Compatibility with core#2835 (display Storage in navbar)
 - #56 Fix UnicodeDecodeError on positions display in storage listing

--- a/src/senaite/storage/browser/container/store_container.py
+++ b/src/senaite/storage/browser/container/store_container.py
@@ -228,7 +228,7 @@ class StoreContainerView(BaseView):
             "data-query": {
                 "portal_type": ["AnalysisRequest"],
                 "review_state": [
-                    "received",
+                    "sample_received",
                     "to_be_verified",
                     "verified",
                     "published",


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes samples that are in received status to be searchable in Samples search widget in storage container's layout view.

Linked issue: https://github.com/senaite/senaite.storage/issues/41

## Current behavior before PR

Cannot store samples in received status via storage container's layout view

## Desired behavior after PR is merged

Can store samples in received status via storage container's layout view

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
