### PR TITLE
Added StorageManager and StorageAssistant and counterpart groups

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #61 Added StorageManager and StorageAssistant roles and counterpart groups
 - #60 Fix sample search when assigning received samples to storage container
 - #59 Fix AttributeError when migrating facilities to DX (2701)
 - #58 Fix ValueError: undefined property 'add_permission' on upgrade

--- a/src/senaite/storage/profiles/default/metadata.xml
+++ b/src/senaite/storage/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>2705</version>
+  <version>2706</version>
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>
     <dependency>profile-senaite.lims:default</dependency>

--- a/src/senaite/storage/profiles/default/rolemap.xml
+++ b/src/senaite/storage/profiles/default/rolemap.xml
@@ -21,20 +21,6 @@
       <role name="StorageManager"/>
       <role name="StorageAssistant"/>
     </permission>
-    <permission name="Modify portal content" acquire="True">
-      <!--
-       StorageManager and StorageAssistant are allowed to modify contents from
-       inside storage's root folder only. Mappings for this permission are
-       overwritten in storage's specific workflow definitions
-      -->
-    </permission>
-    <permission name="Add portal content" acquire="True">
-      <!--
-       StorageManager and StorageAssistant are allowed to add contents inside
-       storage's root folder only. Mappings for this permission are overwritten
-       in storage's specific workflow definitions
-      -->
-    </permission>
 
     <!-- Add permissions -->
     <permission name="senaite.storage: Add Storage Root Folder" acquire="False">

--- a/src/senaite/storage/profiles/default/rolemap.xml
+++ b/src/senaite/storage/profiles/default/rolemap.xml
@@ -8,20 +8,6 @@
 
   <permissions>
 
-    <!-- Plone permissions. We do (acquire="True") to **add** roles -->
-    <permission name="View" acquire="True">
-      <role name="StorageManager"/>
-      <role name="StorageAssistant"/>
-    </permission>
-    <permission name="Access contents information" acquire="True">
-      <role name="StorageManager"/>
-      <role name="StorageAssistant"/>
-    </permission>
-    <permission name="List folder contents" acquire="True">
-      <role name="StorageManager"/>
-      <role name="StorageAssistant"/>
-    </permission>
-
     <!-- Add permissions -->
     <permission name="senaite.storage: Add Storage Root Folder" acquire="False">
       <role name="Manager"/>

--- a/src/senaite/storage/profiles/default/rolemap.xml
+++ b/src/senaite/storage/profiles/default/rolemap.xml
@@ -1,28 +1,68 @@
 <?xml version="1.0"?>
 <rolemap>
 
+  <roles>
+    <role name="StorageManager"/>
+    <role name="StorageAssistant"/>
+  </roles>
+
   <permissions>
+
+    <!-- Plone permissions. We do (acquire="True") to **add** roles -->
+    <permission name="View" acquire="True">
+      <role name="StorageManager"/>
+      <role name="StorageAssistant"/>
+    </permission>
+    <permission name="Access contents information" acquire="True">
+      <role name="StorageManager"/>
+      <role name="StorageAssistant"/>
+    </permission>
+    <permission name="List folder contents" acquire="True">
+      <role name="StorageManager"/>
+      <role name="StorageAssistant"/>
+    </permission>
+    <permission name="Modify portal content" acquire="True">
+      <!--
+       StorageManager and StorageAssistant are allowed to modify contents from
+       inside storage's root folder only. Mappings for this permission are
+       overwritten in storage's specific workflow definitions
+      -->
+    </permission>
+    <permission name="Add portal content" acquire="True">
+      <!--
+       StorageManager and StorageAssistant are allowed to add contents inside
+       storage's root folder only. Mappings for this permission are overwritten
+       in storage's specific workflow definitions
+      -->
+    </permission>
 
     <!-- Add permissions -->
     <permission name="senaite.storage: Add Storage Root Folder" acquire="False">
       <role name="Manager"/>
       <role name="LabManager"/>
+      <role name="StorageManager"/>
     </permission>
     <permission name="senaite.storage: Add Storage Facility" acquire="False">
       <role name="Manager"/>
       <role name="LabManager"/>
-    </permission>
-    <permission name="senaite.storage: Add Storage Container" acquire="False">
-      <role name="Manager"/>
-      <role name="LabManager"/>
-    </permission>
-    <permission name="senaite.storage: Add Storage Samples Container" acquire="False">
-      <role name="Manager"/>
-      <role name="LabManager"/>
+      <role name="StorageManager"/>
     </permission>
     <permission name="senaite.storage: Add Storage Position" acquire="False">
       <role name="Manager"/>
       <role name="LabManager"/>
+      <role name="StorageManager"/>
+    </permission>
+    <permission name="senaite.storage: Add Storage Container" acquire="False">
+      <role name="Manager"/>
+      <role name="LabManager"/>
+      <role name="StorageManager"/>
+      <role name="StorageAssistant"/>
+    </permission>
+    <permission name="senaite.storage: Add Storage Samples Container" acquire="False">
+      <role name="Manager"/>
+      <role name="LabManager"/>
+      <role name="StorageManager"/>
+      <role name="StorageAssistant"/>
     </permission>
 
     <!-- Move Container -->
@@ -30,6 +70,8 @@
       <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
+      <role name="StorageManager"/>
+      <role name="StorageAssistant"/>
     </permission>
 
     <!-- Store/Recover Sample Transition Permissions (sample objects) -->
@@ -37,11 +79,15 @@
       <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
+      <role name="StorageManager"/>
+      <role name="StorageAssistant"/>
     </permission>
     <permission name="senaite.storage: Transition: Recover Sample" acquire="False">
       <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
+      <role name="StorageManager"/>
+      <role name="StorageAssistant"/>
     </permission>
 
     <!-- Add/Recover Samples Transition Permissions (storage listings) -->
@@ -49,11 +95,15 @@
       <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
+      <role name="StorageManager"/>
+      <role name="StorageAssistant"/>
     </permission>
     <permission name="senaite.storage: Transition: Recover Samples" acquire="False">
       <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
+      <role name="StorageManager"/>
+      <role name="StorageAssistant"/>
     </permission>
 
     <!-- Activate/Deactivate Transition Permissions -->
@@ -61,11 +111,13 @@
       <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
+      <role name="StorageManager"/>
     </permission>
     <permission name="senaite.storage: Transition: Deactivate" acquire="False">
       <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
+      <role name="StorageManager"/>
     </permission>
 
   </permissions>

--- a/src/senaite/storage/profiles/default/workflows/senaite_storage_default_workflow/definition.xml
+++ b/src/senaite/storage/profiles/default/workflows/senaite_storage_default_workflow/definition.xml
@@ -46,7 +46,13 @@
     <permission-map name="Access contents information" acquired="True" />
     <permission-map name="Delete objects" acquired="True" />
     <permission-map name="List folder contents" acquired="True" />
-    <permission-map name="Modify portal content" acquired="True" />
+    <permission-map name="Modify portal content" acquired="True">
+      <permission-role>StorageManager</permission-role>
+      <permission-role>StorageAssistant</permission-role>
+    </permission-map>
+    <permission-map name="Add portal content" acquired="True">
+      <permission-role>StorageAssistant</permission-role>
+    </permission-map>
     <permission-map name="View" acquired="True" />
     <!-- senaite.storage Add permissions -->
     <permission-map name="senaite.storage: Add Storage Facility" acquired="True" />

--- a/src/senaite/storage/profiles/default/workflows/senaite_storage_default_workflow/definition.xml
+++ b/src/senaite/storage/profiles/default/workflows/senaite_storage_default_workflow/definition.xml
@@ -21,6 +21,8 @@
   <!-- This governs whether you can get a listing of the contents of a folder; it -->
   <!-- doesn't check whether you have the right to view the objects listed. -->
   <permission>List folder contents</permission>
+  <!-- This governs whether you are allowed to add content to a folder. -->
+  <permission>Add portal content</permission>
 
   <!-- senaite.storage Add permissions -->
   <permission>senaite.storage: Add Storage Facility</permission>

--- a/src/senaite/storage/profiles/default/workflows/senaite_storage_folder_workflow/definition.xml
+++ b/src/senaite/storage/profiles/default/workflows/senaite_storage_folder_workflow/definition.xml
@@ -13,6 +13,7 @@
   <permission>Delete objects</permission>
   <permission>List folder contents</permission>
   <permission>Modify portal content</permission>
+  <permission>Add portal content</permission>
   <permission>View</permission>
 
   <!-- State: active -->
@@ -27,6 +28,8 @@
       <permission-role>RegulatoryInspector</permission-role>
       <permission-role>Sampler</permission-role>
       <permission-role>SamplingCoordinator</permission-role>
+      <permission-role>StorageManager</permission-role>
+      <permission-role>StorageAssistant</permission-role>
       <!-- Plone roles -->
       <permission-role>Manager</permission-role>
       <permission-role>Site Administrator</permission-role>
@@ -41,6 +44,8 @@
       <permission-role>RegulatoryInspector</permission-role>
       <permission-role>Sampler</permission-role>
       <permission-role>SamplingCoordinator</permission-role>
+      <permission-role>StorageManager</permission-role>
+      <permission-role>StorageAssistant</permission-role>
       <!-- Plone roles -->
       <permission-role>Manager</permission-role>
       <permission-role>Site Administrator</permission-role>
@@ -49,6 +54,10 @@
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Add portal content" acquired="True">
+      <!-- Only StorageManager can add (Facilities) inside storage's root -->
+      <permission-role>StorageManager</permission-role>
     </permission-map>
     <permission-map name="View" acquired="False">
       <!-- All except Anonymous and Client -->
@@ -59,6 +68,8 @@
       <permission-role>RegulatoryInspector</permission-role>
       <permission-role>Sampler</permission-role>
       <permission-role>SamplingCoordinator</permission-role>
+      <permission-role>StorageManager</permission-role>
+      <permission-role>StorageAssistant</permission-role>
       <!-- Plone roles -->
       <permission-role>Manager</permission-role>
       <permission-role>Site Administrator</permission-role>

--- a/src/senaite/storage/setuphandlers.py
+++ b/src/senaite/storage/setuphandlers.py
@@ -134,12 +134,6 @@ WORKFLOWS_TO_UPDATE = {
                     cmf_permissions.ListFolderContents: [
                         "StorageManager", "StorageAssistant"
                     ],
-                    # XXX This feels wrong, but this is the permission required
-                    #     for AnalysisRequest/base_view and its analyses tables
-                    #     See https://github.com/senaite/senaite.core/blob/a8cbc4546/src/bika/lims/browser/analysisrequest/configure.zcml#L80-L114
-                    #permissions.ManageAnalysisRequests: [
-                    #    "StorageManager", "StorageAssistant"
-                    #],
                     # Note here we are passing tuples, so these permissions are
                     # set with acquire=False
                     cmf_permissions.ModifyPortalContent: (),
@@ -204,6 +198,15 @@ ROLES = [
         cmf_permissions.View,
         cmf_permissions.AccessContentsInformation,
         cmf_permissions.ListFolderContents,
+        # core's `ManageAnalysisRequests` permission is required for:
+        #
+        #   - AnalysisRequest's `base_view` and its analyses tables
+        #     See https://github.com/senaite/senaite.core/blob/a8cbc4546/src/bika/lims/browser/analysisrequest/configure.zcml#L80-L114
+        #
+        #   - The `storage_store_samples` view (container assignment to
+        #     pre-selected samples) and `storage_store_container` view (samples
+        #     assignment to a pre-selected container)
+        #     See browser/container/configure.zcml
         permissions.ManageAnalysisRequests,
     ]),
     ("StorageAssistant", [
@@ -215,7 +218,7 @@ ROLES = [
 ]
 
 GROUPS = [
-    # Tuple of (group_name, roles_group
+    # Tuple of (group_name, [roles])
     ("Storage Managers", ["Member", "StorageManager"], ),
     ("Storage Assistants", ["Member", "StorageAssistant"], ),
 ]

--- a/src/senaite/storage/setuphandlers.py
+++ b/src/senaite/storage/setuphandlers.py
@@ -21,7 +21,6 @@
 from Acquisition import aq_base
 from bika.lims import api
 from plone import api as ploneapi
-from Products.CMFCore.permissions import ModifyPortalContent
 from senaite.core import permissions
 from Products.CMFCore import permissions as cmf_permissions
 from senaite.core.api.workflow import update_workflow
@@ -143,6 +142,7 @@ WORKFLOWS_TO_UPDATE = {
                     #],
                     # Note here we are passing tuples, so these permissions are
                     # set with acquire=False
+                    cmf_permissions.ModifyPortalContent: (),
                     permissions.AddAnalysis: (),
                     permissions.AddAttachment: (),
                     permissions.TransitionCancelAnalysisRequest: (),
@@ -152,7 +152,6 @@ WORKFLOWS_TO_UPDATE = {
                     permissions.TransitionPreserveSample: (),
                     permissions.TransitionPublishResults: (),
                     permissions.TransitionScheduleSampling: (),
-                    ModifyPortalContent: (),
                 }
             },
         },
@@ -182,6 +181,38 @@ WORKFLOWS_TO_UPDATE = {
         }
     }
 }
+ROLES = [
+    # Tuple of (role, [permissions])
+    #
+    # Permission assignment strategy for this add-on:
+    #
+    # 1. Portal-level permissions (site root):
+    #
+    #    - OUR permissions → roles: use `rolemap.xml`
+    #    - OTHER add-ons' permissions → OUR roles: use `setup_roles()` below
+    #
+    #    Why not use rolemap.xml for both? Because rolemap.xml replaces the
+    #    entire role list for a permission, even with acquire="1". This would
+    #    remove roles that other add-ons have already assigned.
+    #
+    # 2. Content-level permissions (objects managed by workflows):
+    #
+    #    - OUR content types: defined in our DC workflow definitions
+    #    - OTHER add-ons' content types: use WORKFLOWS_TO_UPDATE above
+    #
+    ("StorageManager", [
+        cmf_permissions.View,
+        cmf_permissions.AccessContentsInformation,
+        cmf_permissions.ListFolderContents,
+        permissions.ManageAnalysisRequests,
+    ]),
+    ("StorageAssistant", [
+        cmf_permissions.View,
+        cmf_permissions.AccessContentsInformation,
+        cmf_permissions.ListFolderContents,
+        permissions.ManageAnalysisRequests,
+    ]),
+]
 
 GROUPS = [
     # Tuple of (group_name, roles_group
@@ -219,6 +250,9 @@ def post_install(portal_setup):
 
     # Setup catalogs
     setup_catalogs(portal)
+
+    # Setup roles permissions for portal
+    setup_roles(portal)
 
     # Setup user groups
     setup_user_groups(portal)
@@ -275,8 +309,49 @@ def setup_catalogs(portal):
     setup_catalog_mappings(portal, catalog_mappings=CATALOG_MAPPINGS)
 
 
+def setup_roles(portal):
+    """Setup the top-level permissions (at portal) for product-specific roles.
+    The roles are added for each permission in portal root while keeping the
+    existing acquire setting
+    """
+    logger.info("Setup storage-specific roles ...")
+
+    # Default permissions
+    for role_name, perms in ROLES:
+        for permission in perms:
+            grant_permission_to(portal, permission, role_name)
+
+    logger.info("Setup storage-specific roles [DONE]")
+
+
+def grant_permission_to(folder, permission, role):
+    """Grants a permission to the given role and given folder
+    :param folder: the folder to which the permission for the role must apply
+    :param permission: the permission to be assigned
+    :param role: role to which the permission must be granted
+    :return True if succeeded, otherwise, False
+    """
+    roles = filter(lambda perm: perm.get("selected") == "SELECTED",
+                   folder.rolesOfPermission(permission))
+    roles = map(lambda perm_role: perm_role["name"], roles)
+    if role in roles:
+        # Nothing to do, the role has the permission granted already
+        logger.info("Role '{}' has permission {} for {} already".format(
+            role, repr(permission), repr(folder)))
+        return False
+
+    roles.append(role)
+    acquire = folder.acquiredRolesAreUsedBy(permission) == "CHECKED" and 1 or 0
+    folder.manage_permission(permission, roles=roles, acquire=acquire)
+    folder.reindexObject()
+    logger.info("Added permission {} to role '{}' for {}".format(
+        repr(permission), role, repr(folder)))
+
+    return True
+
+
 def setup_user_groups(portal):
-    """Configure the ptoduct-specific user groups
+    """Configure the product-specific user groups
     """
     logger.info("Setup storage-specific user groups ...")
     groups = portal.portal_groups

--- a/src/senaite/storage/setuphandlers.py
+++ b/src/senaite/storage/setuphandlers.py
@@ -20,9 +20,11 @@
 
 from Acquisition import aq_base
 from bika.lims import api
+from plone import api as ploneapi
 from Products.CMFCore.permissions import ModifyPortalContent
-from Products.DCWorkflow.Guard import Guard
 from senaite.core import permissions
+from Products.CMFCore import permissions as cmf_permissions
+from senaite.core.api.workflow import update_workflow
 from senaite.core.catalog import SAMPLE_CATALOG
 from senaite.core.setuphandlers import setup_catalog_mappings
 from senaite.core.setuphandlers import setup_core_catalogs
@@ -98,27 +100,22 @@ COLUMNS = [
 
 WORKFLOWS_TO_UPDATE = {
     SAMPLE_WORKFLOW: {
-        "permissions": (),
         "states": {
             "sample_received": {
-                # Do not remove transitions already there
-                "preserve_transitions": True,
-                "transitions": ("store",),
+                # Use a list to extend transitions
+                "transitions": ["store"],
             },
             "to_be_verified": {
-                # Do not remove transitions already there
-                "preserve_transitions": True,
-                "transitions": ("store",),
+                # Use a list to extend transitions
+                "transitions": ["store"],
             },
             "verified": {
-                # Do not remove transitions already there
-                "preserve_transitions": True,
-                "transitions": ("store",),
+                # Use a list to extend transitions
+                "transitions": ["store"],
             },
             "published": {
-                # Do not remove transitions already there
-                "preserve_transitions": True,
-                "transitions": ("store",),
+                # Use a list to extend transitions
+                "transitions": ["store"],
             },
             "stored": {
                 "title": "Stored",
@@ -128,6 +125,22 @@ WORKFLOWS_TO_UPDATE = {
                 "permissions_copy_from": "sample_received",
                 # Override permissions
                 "permissions": {
+                    # **Add** (acquire=True) storage-specific roles
+                    cmf_permissions.View: [
+                        "StorageManager", "StorageAssistant"
+                    ],
+                    cmf_permissions.AccessContentsInformation: [
+                        "StorageManager", "StorageAssistant"
+                    ],
+                    cmf_permissions.ListFolderContents: [
+                        "StorageManager", "StorageAssistant"
+                    ],
+                    # XXX This feels wrong, but this is the permission required
+                    #     for AnalysisRequest/base_view and its analyses tables
+                    #     See https://github.com/senaite/senaite.core/blob/a8cbc4546/src/bika/lims/browser/analysisrequest/configure.zcml#L80-L114
+                    #permissions.ManageAnalysisRequests: [
+                    #    "StorageManager", "StorageAssistant"
+                    #],
                     # Note here we are passing tuples, so these permissions are
                     # set with acquire=False
                     permissions.AddAnalysis: (),
@@ -170,6 +183,12 @@ WORKFLOWS_TO_UPDATE = {
     }
 }
 
+GROUPS = [
+    # Tuple of (group_name, roles_group
+    ("Storage Managers", ["Member", "StorageManager"], ),
+    ("Storage Assistants", ["Member", "StorageAssistant"], ),
+]
+
 
 def pre_install(portal_setup):
     """Runs before the first import step of the *default* profile
@@ -200,6 +219,9 @@ def post_install(portal_setup):
 
     # Setup catalogs
     setup_catalogs(portal)
+
+    # Setup user groups
+    setup_user_groups(portal)
 
     # Setup site structure
     setup_site_structure(portal)
@@ -253,111 +275,36 @@ def setup_catalogs(portal):
     setup_catalog_mappings(portal, catalog_mappings=CATALOG_MAPPINGS)
 
 
+def setup_user_groups(portal):
+    """Configure the ptoduct-specific user groups
+    """
+    logger.info("Setup storage-specific user groups ...")
+    groups = portal.portal_groups
+    existing = groups.listGroupIds()
+
+    for group, roles in GROUPS:
+        if group in existing:
+            # group exists already, grant default roles
+            logger.info("Group '%s' already exists. Granted roles: %s" %
+                        (group, ", ".join(roles)))
+            ploneapi.group.grant_roles(groupname=group, roles=roles)
+            break
+
+        # group does not exist yet
+        logger.info("Group '%s' added. Granted roles: %s" %
+                    (group, ", ".join(roles)))
+        groups.addGroup(group, title=group, roles=roles)
+
+    logger.info("Setup storage-specific user groups [DONE]")
+
+
 def setup_workflows(portal):
     """Injects 'store' and 'recover' transitions into workflow
     """
     logger.info("Setup storage workflow ...")
     for wf_id, settings in WORKFLOWS_TO_UPDATE.items():
-        update_workflow(portal, wf_id, settings)
-
-
-def update_workflow(portal, workflow_id, settings):
-    """Injects 'store' and 'recover' transitions into workflow
-    """
-    logger.info("Updating workflow '{}' ...".format(workflow_id))
-    wf_tool = api.get_tool("portal_workflow")
-    workflow = wf_tool.getWorkflowById(workflow_id)
-    if not workflow:
-        logger.warn("Workflow '{}' not found [SKIP]".format(workflow_id))
-    states = settings.get("states", {})
-    for state_id, values in states.items():
-        update_workflow_state(workflow, state_id, values)
-
-    transitions = settings.get("transitions", {})
-    for transition_id, values in transitions.items():
-        update_workflow_transition(workflow, transition_id, values)
-
-
-def update_workflow_state(workflow, status_id, settings):
-    logger.info("Updating workflow '{}', status: '{}' ..."
-                .format(workflow.id, status_id))
-
-    # Create the status (if does not exist yet)
-    new_status = workflow.states.get(status_id)
-    if not new_status:
-        workflow.states.addState(status_id)
-        new_status = workflow.states.get(status_id)
-
-    # Set basic info (title, description, etc.)
-    new_status.title = settings.get("title", new_status.title)
-    new_status.description = settings.get("description", new_status.description)
-
-    # Set transitions
-    trans = settings.get("transitions", ())
-    if settings.get("preserve_transitions", False):
-        trans = tuple(set(new_status.transitions+trans))
-    new_status.transitions = trans
-
-    # Set permissions
-    update_workflow_state_permissions(workflow, new_status, settings)
-
-
-def update_workflow_state_permissions(workflow, status, settings):
-    # Copy permissions from another state?
-    permissions_copy_from = settings.get("permissions_copy_from", None)
-    if permissions_copy_from:
-        logger.info("Copying permissions from '{}' to '{}' ..."
-                    .format(permissions_copy_from, status.id))
-        copy_from_state = workflow.states.get(permissions_copy_from)
-        if not copy_from_state:
-            logger.info("State '{}' not found [SKIP]".format(copy_from_state))
-        else:
-            for perm_id in copy_from_state.permissions:
-                perm_info = copy_from_state.getPermissionInfo(perm_id)
-                acquired = perm_info.get("acquired", 1)
-                roles = perm_info.get("roles", acquired and [] or ())
-                logger.info("Setting permission '{}' (acquired={}): '{}'"
-                            .format(perm_id, repr(acquired), ', '.join(roles)))
-                status.setPermission(perm_id, acquired, roles)
-
-    # Override permissions
-    logger.info("Overriding permissions for '{}' ...".format(status.id))
-    state_permissions = settings.get('permissions', {})
-    if not state_permissions:
-        logger.info(
-            "No permissions set for '{}' [SKIP]".format(status.id))
-        return
-    for permission_id, roles in state_permissions.items():
-        state_roles = roles and roles or ()
-        if isinstance(state_roles, tuple):
-            acq = 0
-        else:
-            acq = 1
-        logger.info("Setting permission '{}' (acquired={}): '{}'"
-                    .format(permission_id, repr(acq),
-                            ', '.join(state_roles)))
-        status.setPermission(permission_id, acq, state_roles)
-
-
-def update_workflow_transition(workflow, transition_id, settings):
-    logger.info("Updating workflow '{}', transition: '{}'"
-                .format(workflow.id, transition_id))
-    if transition_id not in workflow.transitions:
-        workflow.transitions.addTransition(transition_id)
-    transition = workflow.transitions.get(transition_id)
-    transition.setProperties(
-        title=settings.get("title"),
-        new_state_id=settings.get("new_state"),
-        after_script_name=settings.get("after_script", ""),
-        actbox_name=settings.get("action", settings.get("title"))
-    )
-    guard = transition.guard or Guard()
-    guard_props = {"guard_permissions": "",
-                   "guard_roles": "",
-                   "guard_expr": ""}
-    guard_props = settings.get("guard", guard_props)
-    guard.changeFromProperties(guard_props)
-    transition.guard = guard
+        update_workflow(wf_id, **settings)
+    logger.info("Setup storage workflow [DONE]")
 
 
 def setup_id_formatting(portal, format=None):

--- a/src/senaite/storage/subscribers/upgrade.py
+++ b/src/senaite/storage/subscribers/upgrade.py
@@ -55,9 +55,6 @@ def afterUpgradeStepHandler(event):
     # Setup catalogs
     setup_catalogs(portal)
 
-    # setup the roles permissions
-    #setup_roles_permissions(portal)
-
     # setup user groups
     setup_user_groups(portal)
 

--- a/src/senaite/storage/subscribers/upgrade.py
+++ b/src/senaite/storage/subscribers/upgrade.py
@@ -26,6 +26,7 @@ from senaite.storage import is_installed
 from senaite.storage import logger
 from senaite.storage import PRODUCT_NAME
 from senaite.storage.setuphandlers import setup_catalogs
+from senaite.storage.setuphandlers import setup_user_groups
 from senaite.storage.setuphandlers import setup_workflows
 
 
@@ -53,6 +54,12 @@ def afterUpgradeStepHandler(event):
 
     # Setup catalogs
     setup_catalogs(portal)
+
+    # setup the roles permissions
+    #setup_roles_permissions(portal)
+
+    # setup user groups
+    setup_user_groups(portal)
 
     # Setup workflows
     setup_workflows(portal)

--- a/src/senaite/storage/subscribers/upgrade.py
+++ b/src/senaite/storage/subscribers/upgrade.py
@@ -26,6 +26,7 @@ from senaite.storage import is_installed
 from senaite.storage import logger
 from senaite.storage import PRODUCT_NAME
 from senaite.storage.setuphandlers import setup_catalogs
+from senaite.storage.setuphandlers import setup_roles
 from senaite.storage.setuphandlers import setup_user_groups
 from senaite.storage.setuphandlers import setup_workflows
 
@@ -54,6 +55,9 @@ def afterUpgradeStepHandler(event):
 
     # Setup catalogs
     setup_catalogs(portal)
+
+    # setup roles permissions for portal
+    setup_roles(portal)
 
     # setup user groups
     setup_user_groups(portal)

--- a/src/senaite/storage/tests/doctests/StorageAssistant.rst
+++ b/src/senaite/storage/tests/doctests/StorageAssistant.rst
@@ -1,0 +1,547 @@
+StorageAssistant Role
+---------------------
+
+Running this test from the buildout directory:
+
+    bin/test test_textual_doctests -t StorageAssistant
+
+Test Setup
+..........
+
+Needed Imports:
+
+    >>> from AccessControl.unauthorized import Unauthorized
+    >>> from bika.lims import api
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+    >>> from bika.lims.workflow import doActionFor as do_action_for
+    >>> from bika.lims.workflow import getAllowedTransitions
+    >>> from DateTime import DateTime
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+
+Functional Helpers:
+
+    >>> def new_sample(services, client, contact, sampletype):
+    ...     values = {
+    ...         'Client': client.UID(),
+    ...         'Contact': contact.UID(),
+    ...         'DateSampled': DateTime().strftime("%Y-%m-%d"),
+    ...         'SampleType': sampletype.UID()}
+    ...     service_uids = map(api.get_uid, services)
+    ...     sample = create_analysisrequest(client, request, values, service_uids)
+    ...     return sample
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> setup = portal.setup
+    >>> bikasetup = portal.bika_setup
+    >>> storage = portal.senaite_storage
+
+
+Create base storage structure as LabManager
+............................................
+
+StorageAssistant cannot create facilities, so we need to create the base
+storage structure first. Set LabManager role:
+
+    >>> setRoles(portal, TEST_USER_ID, ["LabManager"])
+
+Create a facility:
+
+    >>> facility = api.create(storage, "StorageFacility", title="Test Facility")
+    >>> facility
+    <StorageFacility at /plone/senaite_storage/SF-00001>
+
+Create base objects for samples:
+
+    >>> client = api.create(portal.clients, "Client", Name="Test Client", ClientID="TC")
+    >>> contact = api.create(client, "Contact", Firstname="Test", Lastname="Contact")
+    >>> labcontact = api.create(bikasetup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(setup.departments, "Department", title="Chemistry", Manager=labcontact)
+    >>> sampletype = api.create(setup.sampletypes, "SampleType", title="Water", Prefix="W")
+    >>> category = api.create(setup.analysiscategories, "AnalysisCategory", title="Metals", Department=department)
+    >>> service = api.create(bikasetup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Category=category.UID())
+
+
+Switch to StorageAssistant role
+...............................
+
+Now set StorageAssistant role:
+
+    >>> setRoles(portal, TEST_USER_ID, ["StorageAssistant"])
+
+
+StorageAssistant CANNOT create facilities
+.........................................
+
+StorageAssistant does not have permission to create `StorageFacility` objects
+inside the storage root folder:
+
+    >>> try:
+    ...     api.create(storage, "StorageFacility", title="Unauthorized Facility")
+    ...     raise AssertionError("Should have raised Unauthorized")
+    ... except Unauthorized:
+    ...     pass
+
+
+StorageAssistant CAN create positions
+.....................................
+
+StorageAssistant can create `StoragePosition` objects inside a facility:
+
+    >>> position = api.create(facility, "StoragePosition", title="Room A")
+    >>> position
+    <StoragePosition at /plone/senaite_storage/SF-00001/SP-00001>
+
+    >>> position.Title()
+    'Room A'
+
+    >>> position.aq_parent == facility
+    True
+
+Create another position for move tests:
+
+    >>> position_b = api.create(facility, "StoragePosition", title="Room B")
+    >>> position_b
+    <StoragePosition at /plone/senaite_storage/SF-00001/SP-00002>
+
+
+StorageAssistant CAN create containers
+......................................
+
+StorageAssistant can create `StorageContainer` objects inside a position:
+
+    >>> container = api.create(position, "StorageContainer", title="Freezer A")
+    >>> container
+    <StorageContainer at /plone/senaite_storage/SF-00001/SP-00001/SC-00001>
+
+    >>> container.Title()
+    'Freezer A'
+
+    >>> container.aq_parent == position
+    True
+
+StorageAssistant can also create containers inside other containers (nested):
+
+    >>> nested_container = api.create(container, "StorageContainer", title="Shelf 1")
+    >>> nested_container
+    <StorageContainer at /plone/senaite_storage/SF-00001/SP-00001/SC-00001/SC-00002>
+
+    >>> nested_container.Title()
+    'Shelf 1'
+
+    >>> nested_container.aq_parent == container
+    True
+
+
+StorageAssistant CAN edit containers
+....................................
+
+StorageAssistant can modify container properties:
+
+    >>> container.setTitle("Freezer A-1")
+    >>> container.Title()
+    'Freezer A-1'
+
+    >>> nested_container.setTitle("Shelf 1-A")
+    >>> nested_container.Title()
+    'Shelf 1-A'
+
+
+StorageAssistant CAN create samples containers
+..............................................
+
+StorageAssistant can create `StorageSamplesContainer` objects inside a container:
+
+    >>> samples_container = api.create(container, "StorageSamplesContainer", title="Box A", Rows=3, Columns=3)
+    >>> samples_container
+    <StorageSamplesContainer at /plone/senaite_storage/SF-00001/SP-00001/SC-00001/SS-00001>
+
+    >>> samples_container.Title()
+    'Box A'
+
+    >>> samples_container.aq_parent == container
+    True
+
+    >>> samples_container.getRows()
+    3
+
+    >>> samples_container.getColumns()
+    3
+
+    >>> samples_container.get_samples_capacity()
+    9
+
+
+StorageAssistant CAN edit samples containers
+............................................
+
+StorageAssistant can modify samples container properties:
+
+    >>> samples_container.setTitle("Box A-1")
+    >>> samples_container.Title()
+    'Box A-1'
+
+
+StorageAssistant CAN move containers
+....................................
+
+The `move_container` transition is available for containers:
+
+    >>> "move_container" in getAllowedTransitions(nested_container)
+    True
+
+Move a container from one position to another:
+
+    >>> "/".join(nested_container.getPhysicalPath())
+    '/plone/senaite_storage/SF-00001/SP-00001/SC-00001/SC-00002'
+
+    >>> nested_container = api.move_object(nested_container, position_b, check_constraints=False)
+    >>> nested_container
+    <StorageContainer at /plone/senaite_storage/SF-00001/SP-00002/SC-00002>
+
+    >>> nested_container.aq_parent == position_b
+    True
+
+Create another container to test moving inside containers:
+
+    >>> another_container = api.create(position_b, "StorageContainer", title="Cabinet B")
+    >>> another_container
+    <StorageContainer at /plone/senaite_storage/SF-00001/SP-00002/SC-00003>
+
+Move a container inside another container:
+
+    >>> nested_container = api.move_object(nested_container, another_container, check_constraints=False)
+    >>> nested_container
+    <StorageContainer at /plone/senaite_storage/SF-00001/SP-00002/SC-00003/SC-00002>
+
+    >>> nested_container.aq_parent == another_container
+    True
+
+
+StorageAssistant CAN move samples containers
+............................................
+
+The `move_container` transition is available for samples containers:
+
+    >>> "move_container" in getAllowedTransitions(samples_container)
+    True
+
+Check the current location of the samples container:
+
+    >>> "/".join(samples_container.getPhysicalPath())
+    '/plone/senaite_storage/SF-00001/SP-00001/SC-00001/SS-00001'
+
+Move the samples container to a different container:
+
+    >>> samples_container = api.move_object(samples_container, another_container, check_constraints=False)
+    >>> samples_container
+    <StorageSamplesContainer at /plone/senaite_storage/SF-00001/SP-00002/SC-00003/SS-00001>
+
+    >>> samples_container.aq_parent == another_container
+    True
+
+
+StorageAssistant CAN store samples
+..................................
+
+First, create and receive a sample as LabClerk:
+
+    >>> setRoles(portal, TEST_USER_ID, ["LabClerk"])
+
+    >>> sample = new_sample([service], client, contact, sampletype)
+    >>> api.get_workflow_status_of(sample)
+    'sample_due'
+
+    >>> transitioned = do_action_for(sample, "receive")
+    >>> api.get_workflow_status_of(sample)
+    'sample_received'
+
+Now switch to StorageAssistant role:
+
+    >>> setRoles(portal, TEST_USER_ID, ["StorageAssistant"])
+
+The `store` transition is available for received samples:
+
+    >>> "store" in getAllowedTransitions(sample)
+    True
+
+StorageAssistant can store the sample:
+
+    >>> samples_container.add_object_at(sample, 0, 0)
+    True
+
+    >>> api.get_workflow_status_of(sample)
+    'stored'
+
+    >>> samples_container.get_samples_utilization()
+    1
+
+
+StorageAssistant CAN recover samples
+....................................
+
+The `recover` transition is available for stored samples:
+
+    >>> "recover" in getAllowedTransitions(sample)
+    True
+
+StorageAssistant can recover samples:
+
+    >>> transitioned = do_action_for(sample, "recover")
+    >>> api.get_workflow_status_of(sample)
+    'sample_received'
+
+    >>> samples_container.get_samples_utilization()
+    0
+
+
+StorageAssistant CAN store and recover samples created by other users
+.....................................................................
+
+Create a sample as LabClerk and store it:
+
+    >>> setRoles(portal, TEST_USER_ID, ["LabClerk"])
+
+    >>> sample2 = new_sample([service], client, contact, sampletype)
+    >>> transitioned = do_action_for(sample2, "receive")
+    >>> samples_container.add_object_at(sample2, 1, 0)
+    True
+
+    >>> api.get_workflow_status_of(sample2)
+    'stored'
+
+Switch to StorageAssistant and recover the sample:
+
+    >>> setRoles(portal, TEST_USER_ID, ["StorageAssistant"])
+
+    >>> "recover" in getAllowedTransitions(sample2)
+    True
+
+    >>> transitioned = do_action_for(sample2, "recover")
+    >>> api.get_workflow_status_of(sample2)
+    'sample_received'
+
+Store it again as StorageAssistant:
+
+    >>> samples_container.add_object_at(sample2, 2, 0)
+    True
+
+    >>> api.get_workflow_status_of(sample2)
+    'stored'
+
+    >>> samples_container.get_samples_utilization()
+    1
+
+
+StorageAssistant CANNOT deactivate containers
+.............................................
+
+Create a fresh container to test deactivate/activate permissions:
+
+    >>> test_container = api.create(position_b, "StorageContainer", title="Test Container")
+    >>> test_container
+    <StorageContainer at /plone/senaite_storage/SF-00001/SP-00002/SC-00004>
+
+StorageAssistant does not have permission to deactivate containers:
+
+    >>> "deactivate" in getAllowedTransitions(test_container)
+    False
+
+    >>> transitioned = do_action_for(test_container, "deactivate")
+    >>> transitioned[0]
+    False
+
+The container remains active:
+
+    >>> api.get_workflow_status_of(test_container)
+    'active'
+
+
+StorageAssistant CANNOT activate containers
+...........................................
+
+First, let's deactivate the container as LabManager:
+
+    >>> setRoles(portal, TEST_USER_ID, ["LabManager"])
+    >>> transitioned = do_action_for(test_container, "deactivate")
+    >>> api.get_workflow_status_of(test_container)
+    'inactive'
+
+Switch back to StorageAssistant:
+
+    >>> setRoles(portal, TEST_USER_ID, ["StorageAssistant"])
+
+StorageAssistant cannot activate the container:
+
+    >>> "activate" in getAllowedTransitions(test_container)
+    False
+
+    >>> transitioned = do_action_for(test_container, "activate")
+    >>> transitioned[0]
+    False
+
+The container remains inactive:
+
+    >>> api.get_workflow_status_of(test_container)
+    'inactive'
+
+
+StorageAssistant CANNOT deactivate samples containers
+.....................................................
+
+Create a fresh samples container to test deactivate/activate permissions:
+
+    >>> setRoles(portal, TEST_USER_ID, ["LabManager"])
+    >>> test_sc_container = api.create(position_b, "StorageContainer", title="Test SC Container")
+    >>> test_samples_container = api.create(test_sc_container, "StorageSamplesContainer", title="Test Box", Rows=2, Columns=2)
+
+    >>> setRoles(portal, TEST_USER_ID, ["StorageAssistant"])
+
+StorageAssistant does not have permission to deactivate samples containers:
+
+    >>> "deactivate" in getAllowedTransitions(test_samples_container)
+    False
+
+    >>> transitioned = do_action_for(test_samples_container, "deactivate")
+    >>> transitioned[0]
+    False
+
+The samples container remains active:
+
+    >>> api.get_workflow_status_of(test_samples_container)
+    'active'
+
+
+StorageAssistant CANNOT activate samples containers
+...................................................
+
+First, let's deactivate the samples container as LabManager:
+
+    >>> setRoles(portal, TEST_USER_ID, ["LabManager"])
+    >>> transitioned = do_action_for(test_samples_container, "deactivate")
+    >>> api.get_workflow_status_of(test_samples_container)
+    'inactive'
+
+Switch back to StorageAssistant:
+
+    >>> setRoles(portal, TEST_USER_ID, ["StorageAssistant"])
+
+StorageAssistant cannot activate the samples container:
+
+    >>> "activate" in getAllowedTransitions(test_samples_container)
+    False
+
+    >>> transitioned = do_action_for(test_samples_container, "activate")
+    >>> transitioned[0]
+    False
+
+The samples container remains inactive:
+
+    >>> api.get_workflow_status_of(test_samples_container)
+    'inactive'
+
+
+StorageAssistant CANNOT deactivate facilities
+.............................................
+
+StorageAssistant does not have permission to deactivate facilities:
+
+    >>> "deactivate" in getAllowedTransitions(facility)
+    False
+
+    >>> transitioned = do_action_for(facility, "deactivate")
+    >>> transitioned[0]
+    False
+
+The facility remains active:
+
+    >>> api.get_workflow_status_of(facility)
+    'active'
+
+
+StorageAssistant CANNOT activate facilities
+...........................................
+
+First, let's deactivate the facility as LabManager:
+
+    >>> setRoles(portal, TEST_USER_ID, ["LabManager"])
+    >>> transitioned = do_action_for(facility, "deactivate")
+    >>> api.get_workflow_status_of(facility)
+    'inactive'
+
+Switch back to StorageAssistant:
+
+    >>> setRoles(portal, TEST_USER_ID, ["StorageAssistant"])
+
+StorageAssistant cannot activate the facility:
+
+    >>> "activate" in getAllowedTransitions(facility)
+    False
+
+    >>> transitioned = do_action_for(facility, "activate")
+    >>> transitioned[0]
+    False
+
+The facility remains inactive:
+
+    >>> api.get_workflow_status_of(facility)
+    'inactive'
+
+
+StorageAssistant CANNOT deactivate positions
+............................................
+
+First, reactivate the facility as LabManager so we can test positions:
+
+    >>> setRoles(portal, TEST_USER_ID, ["LabManager"])
+    >>> transitioned = do_action_for(facility, "activate")
+    >>> api.get_workflow_status_of(facility)
+    'active'
+
+    >>> setRoles(portal, TEST_USER_ID, ["StorageAssistant"])
+
+StorageAssistant does not have permission to deactivate positions:
+
+    >>> "deactivate" in getAllowedTransitions(position)
+    False
+
+    >>> transitioned = do_action_for(position, "deactivate")
+    >>> transitioned[0]
+    False
+
+The position remains active:
+
+    >>> api.get_workflow_status_of(position)
+    'active'
+
+
+StorageAssistant CANNOT activate positions
+..........................................
+
+First, let's deactivate the position as LabManager:
+
+    >>> setRoles(portal, TEST_USER_ID, ["LabManager"])
+    >>> transitioned = do_action_for(position, "deactivate")
+    >>> api.get_workflow_status_of(position)
+    'inactive'
+
+Switch back to StorageAssistant:
+
+    >>> setRoles(portal, TEST_USER_ID, ["StorageAssistant"])
+
+StorageAssistant cannot activate the position:
+
+    >>> "activate" in getAllowedTransitions(position)
+    False
+
+    >>> transitioned = do_action_for(position, "activate")
+    >>> transitioned[0]
+    False
+
+The position remains inactive:
+
+    >>> api.get_workflow_status_of(position)
+    'inactive'

--- a/src/senaite/storage/tests/doctests/StorageAssistant.rst
+++ b/src/senaite/storage/tests/doctests/StorageAssistant.rst
@@ -86,6 +86,21 @@ inside the storage root folder:
     ...     pass
 
 
+StorageAssistant CAN edit facilities
+.....................................
+
+Even though StorageAssistant cannot create facilities, they can edit existing
+facilities created by other users:
+
+    >>> facility.setTitle("Updated Facility Name")
+    >>> facility.Title()
+    'Updated Facility Name'
+
+Reset the title:
+
+    >>> facility.setTitle("Test Facility")
+
+
 StorageAssistant CAN create positions
 .....................................
 
@@ -106,6 +121,20 @@ Create another position for move tests:
     >>> position_b = api.create(facility, "StoragePosition", title="Room B")
     >>> position_b
     <StoragePosition at /plone/senaite_storage/SF-00001/SP-00002>
+
+
+StorageAssistant CAN edit positions
+....................................
+
+StorageAssistant can modify position properties:
+
+    >>> position.setTitle("Cold Room A")
+    >>> position.Title()
+    'Cold Room A'
+
+Reset the title:
+
+    >>> position.setTitle("Room A")
 
 
 StorageAssistant CAN create containers

--- a/src/senaite/storage/tests/doctests/StorageManager.rst
+++ b/src/senaite/storage/tests/doctests/StorageManager.rst
@@ -1,0 +1,290 @@
+StorageManager Role
+-------------------
+
+Running this test from the buildout directory:
+
+    bin/test test_textual_doctests -t StorageManager
+
+Test Setup
+..........
+
+Needed Imports:
+
+    >>> from bika.lims import api
+    >>> from bika.lims.workflow import doActionFor as do_action_for
+    >>> from bika.lims.workflow import getAllowedTransitions
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> storage = portal.senaite_storage
+
+Set the test user with `StorageManager` role:
+
+    >>> setRoles(portal, TEST_USER_ID, ["StorageManager"])
+
+
+StorageManager can create facilities
+....................................
+
+The storage root folder (`senaite_storage`) allows users with `StorageManager`
+role to create `StorageFacility` objects inside it.
+
+    >>> facility = api.create(storage, "StorageFacility", title="Test Facility")
+    >>> facility
+    <StorageFacility at /plone/senaite_storage/SF-00001>
+
+    >>> facility.Title()
+    'Test Facility'
+
+Verify the facility was created in the correct location:
+
+    >>> facility.aq_parent == storage
+    True
+
+    >>> "/".join(facility.getPhysicalPath())
+    '/plone/senaite_storage/SF-00001'
+
+
+StorageManager can edit facilities
+..................................
+
+StorageManager can modify facility properties:
+
+    >>> facility.setTitle("Updated Facility Name")
+    >>> facility.Title()
+    'Updated Facility Name'
+
+
+StorageManager can deactivate and activate facilities
+.....................................................
+
+Check the allowed transitions for the facility:
+
+    >>> getAllowedTransitions(facility)
+    ['deactivate']
+
+StorageManager can deactivate a facility:
+
+    >>> transitioned = do_action_for(facility, "deactivate")
+    >>> api.get_workflow_status_of(facility)
+    'inactive'
+
+And activate it again:
+
+    >>> getAllowedTransitions(facility)
+    ['activate']
+
+    >>> transitioned = do_action_for(facility, "activate")
+    >>> api.get_workflow_status_of(facility)
+    'active'
+
+
+StorageManager can create positions inside facilities
+.....................................................
+
+StorageManager can create `StoragePosition` objects inside a facility:
+
+    >>> position = api.create(facility, "StoragePosition", title="Room A")
+    >>> position
+    <StoragePosition at /plone/senaite_storage/SF-00001/SP-00001>
+
+    >>> position.Title()
+    'Room A'
+
+    >>> position.aq_parent == facility
+    True
+
+
+StorageManager can edit positions
+.................................
+
+StorageManager can modify position properties:
+
+    >>> position.setTitle("Cold Room A")
+    >>> position.Title()
+    'Cold Room A'
+
+
+StorageManager can deactivate and activate positions
+....................................................
+
+Check the allowed transitions for the position:
+
+    >>> getAllowedTransitions(position)
+    ['deactivate']
+
+StorageManager can deactivate a position:
+
+    >>> transitioned = do_action_for(position, "deactivate")
+    >>> api.get_workflow_status_of(position)
+    'inactive'
+
+And activate it again:
+
+    >>> getAllowedTransitions(position)
+    ['activate']
+
+    >>> transitioned = do_action_for(position, "activate")
+    >>> api.get_workflow_status_of(position)
+    'active'
+
+
+StorageManager can create containers
+....................................
+
+StorageManager can create `StorageContainer` objects inside a position:
+
+    >>> container = api.create(position, "StorageContainer", title="Freezer A")
+    >>> container
+    <StorageContainer at /plone/senaite_storage/SF-00001/SP-00001/SC-00001>
+
+    >>> container.Title()
+    'Freezer A'
+
+    >>> container.aq_parent == position
+    True
+
+StorageManager can also create containers inside other containers (nested):
+
+    >>> nested_container = api.create(container, "StorageContainer", title="Shelf 1")
+    >>> nested_container
+    <StorageContainer at /plone/senaite_storage/SF-00001/SP-00001/SC-00001/SC-00002>
+
+    >>> nested_container.Title()
+    'Shelf 1'
+
+    >>> nested_container.aq_parent == container
+    True
+
+
+StorageManager can edit containers
+..................................
+
+StorageManager can modify container properties:
+
+    >>> container.setTitle("Freezer A-1")
+    >>> container.Title()
+    'Freezer A-1'
+
+    >>> nested_container.setTitle("Shelf 1-A")
+    >>> nested_container.Title()
+    'Shelf 1-A'
+
+
+StorageManager can deactivate and activate containers
+.....................................................
+
+Check the allowed transitions for the container:
+
+    >>> "deactivate" in getAllowedTransitions(container)
+    True
+
+StorageManager can deactivate a container:
+
+    >>> transitioned = do_action_for(container, "deactivate")
+    >>> api.get_workflow_status_of(container)
+    'inactive'
+
+Deactivating a container also deactivates nested containers:
+
+    >>> api.get_workflow_status_of(nested_container)
+    'inactive'
+
+And activate it again:
+
+    >>> "activate" in getAllowedTransitions(container)
+    True
+
+    >>> transitioned = do_action_for(container, "activate")
+    >>> api.get_workflow_status_of(container)
+    'active'
+
+Activating a container also activates nested containers:
+
+    >>> api.get_workflow_status_of(nested_container)
+    'active'
+
+
+StorageManager can create samples containers
+............................................
+
+StorageManager can create `StorageSamplesContainer` objects inside a container:
+
+    >>> samples_container = api.create(container, "StorageSamplesContainer", title="Box A", Rows=3, Columns=3)
+    >>> samples_container
+    <StorageSamplesContainer at /plone/senaite_storage/SF-00001/SP-00001/SC-00001/SS-00001>
+
+    >>> samples_container.Title()
+    'Box A'
+
+    >>> samples_container.aq_parent == container
+    True
+
+    >>> samples_container.getRows()
+    3
+
+    >>> samples_container.getColumns()
+    3
+
+    >>> samples_container.get_samples_capacity()
+    9
+
+
+StorageManager can edit samples containers
+..........................................
+
+StorageManager can modify samples container properties:
+
+    >>> samples_container.setTitle("Box A-1")
+    >>> samples_container.Title()
+    'Box A-1'
+
+
+StorageManager can deactivate and activate samples containers
+.............................................................
+
+Check the allowed transitions for the samples container:
+
+    >>> "deactivate" in getAllowedTransitions(samples_container)
+    True
+
+StorageManager can deactivate a samples container:
+
+    >>> transitioned = do_action_for(samples_container, "deactivate")
+    >>> api.get_workflow_status_of(samples_container)
+    'inactive'
+
+And activate it again:
+
+    >>> "activate" in getAllowedTransitions(samples_container)
+    True
+
+    >>> transitioned = do_action_for(samples_container, "activate")
+    >>> api.get_workflow_status_of(samples_container)
+    'active'
+
+
+StorageManager can create full storage hierarchy
+................................................
+
+Create a complete storage hierarchy:
+
+    >>> facility2 = api.create(storage, "StorageFacility", title="Main Storage")
+    >>> facility2
+    <StorageFacility at /plone/senaite_storage/SF-00002>
+
+    >>> position2 = api.create(facility2, "StoragePosition", title="Room B")
+    >>> position2
+    <StoragePosition at /plone/senaite_storage/SF-00002/SP-00002>
+
+    >>> container2 = api.create(position2, "StorageContainer", title="Freezer 1")
+    >>> container2
+    <StorageContainer at /plone/senaite_storage/SF-00002/SP-00002/SC-00003>
+
+    >>> samples_container2 = api.create(container2, "StorageSamplesContainer", title="Box 1", Rows=3, Columns=3)
+    >>> samples_container2
+    <StorageSamplesContainer at /plone/senaite_storage/SF-00002/SP-00002/SC-00003/SS-00002>

--- a/src/senaite/storage/tests/doctests/StorageManager.rst
+++ b/src/senaite/storage/tests/doctests/StorageManager.rst
@@ -392,7 +392,7 @@ Now login back as TEST_USER with `LabClerk` role to create and receive the sampl
     >>> api.get_workflow_status_of(sample)
     'sample_received'
 
-Store the sample in the samples container:
+LabClerk stores the sample in the samples container:
 
     >>> samples_container.add_object_at(sample, 0, 0)
     True
@@ -412,7 +412,7 @@ The `recover` transition is available for stored samples:
     >>> "recover" in getAllowedTransitions(sample)
     True
 
-StorageManager can recover the sample from storage:
+StorageManager can recover samples that were stored by other users:
 
     >>> transitioned = do_action_for(sample, "recover")
     >>> api.get_workflow_status_of(sample)
@@ -420,6 +420,20 @@ StorageManager can recover the sample from storage:
 
     >>> samples_container.get_samples_utilization()
     0
+
+StorageManager can also store samples:
+
+    >>> "store" in getAllowedTransitions(sample)
+    True
+
+    >>> samples_container.add_object_at(sample, 1, 0)
+    True
+
+    >>> api.get_workflow_status_of(sample)
+    'stored'
+
+    >>> samples_container.get_samples_utilization()
+    1
 
 
 StorageManager can create full storage hierarchy

--- a/src/senaite/storage/tests/doctests/StorageManager.rst
+++ b/src/senaite/storage/tests/doctests/StorageManager.rst
@@ -11,15 +11,34 @@ Test Setup
 Needed Imports:
 
     >>> from bika.lims import api
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
     >>> from bika.lims.workflow import doActionFor as do_action_for
     >>> from bika.lims.workflow import getAllowedTransitions
+    >>> from DateTime import DateTime
+    >>> from plone.app.testing import login
     >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import SITE_OWNER_NAME
     >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_NAME
+
+Functional Helpers:
+
+    >>> def new_sample(services, client, contact, sampletype):
+    ...     values = {
+    ...         'Client': client.UID(),
+    ...         'Contact': contact.UID(),
+    ...         'DateSampled': DateTime().strftime("%Y-%m-%d"),
+    ...         'SampleType': sampletype.UID()}
+    ...     service_uids = map(api.get_uid, services)
+    ...     sample = create_analysisrequest(client, request, values, service_uids)
+    ...     return sample
 
 Variables:
 
     >>> portal = self.portal
     >>> request = self.request
+    >>> setup = portal.setup
+    >>> bikasetup = portal.bika_setup
     >>> storage = portal.senaite_storage
 
 Set the test user with `StorageManager` role:
@@ -339,6 +358,68 @@ Move the samples container to a different container:
 
     >>> "/".join(samples_container.getPhysicalPath())
     '/plone/senaite_storage/SF-00001/SP-00002/SC-00003/SS-00001'
+
+
+StorageManager can recover samples from samples containers
+..........................................................
+
+Users with `StorageManager` role can recover samples from storage, but they
+cannot create samples. Samples must be created by users with other roles such
+as `LabClerk`.
+
+First, we need to create some base objects for samples. We login as site owner
+to create the setup objects (so TEST_USER won't have Owner role on them):
+
+    >>> login(portal.aq_parent, SITE_OWNER_NAME)
+    >>> client = api.create(portal.clients, "Client", Name="Test Client", ClientID="TC")
+    >>> contact = api.create(client, "Contact", Firstname="Test", Lastname="Contact")
+    >>> labcontact = api.create(bikasetup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(setup.departments, "Department", title="Chemistry", Manager=labcontact)
+    >>> sampletype = api.create(setup.sampletypes, "SampleType", title="Water", Prefix="W")
+    >>> category = api.create(setup.analysiscategories, "AnalysisCategory", title="Metals", Department=department)
+    >>> service = api.create(bikasetup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Category=category.UID())
+
+Now login back as TEST_USER with `LabClerk` role to create and receive the sample:
+
+    >>> login(portal, TEST_USER_NAME)
+    >>> setRoles(portal, TEST_USER_ID, ["LabClerk"])
+
+    >>> sample = new_sample([service], client, contact, sampletype)
+    >>> api.get_workflow_status_of(sample)
+    'sample_due'
+
+    >>> transitioned = do_action_for(sample, "receive")
+    >>> api.get_workflow_status_of(sample)
+    'sample_received'
+
+Store the sample in the samples container:
+
+    >>> samples_container.add_object_at(sample, 0, 0)
+    True
+
+    >>> api.get_workflow_status_of(sample)
+    'stored'
+
+    >>> samples_container.get_samples_utilization()
+    1
+
+Now switch to `StorageManager` role to recover the sample:
+
+    >>> setRoles(portal, TEST_USER_ID, ["StorageManager"])
+
+The `recover` transition is available for stored samples:
+
+    >>> "recover" in getAllowedTransitions(sample)
+    True
+
+StorageManager can recover the sample from storage:
+
+    >>> transitioned = do_action_for(sample, "recover")
+    >>> api.get_workflow_status_of(sample)
+    'sample_received'
+
+    >>> samples_container.get_samples_utilization()
+    0
 
 
 StorageManager can create full storage hierarchy

--- a/src/senaite/storage/tests/doctests/StorageManager.rst
+++ b/src/senaite/storage/tests/doctests/StorageManager.rst
@@ -209,6 +209,52 @@ Activating a container also activates nested containers:
     'active'
 
 
+StorageManager can move containers
+..................................
+
+The `move_container` transition is available for containers:
+
+    >>> "move_container" in getAllowedTransitions(container)
+    True
+
+    >>> "move_container" in getAllowedTransitions(nested_container)
+    True
+
+Create a second position to move containers to:
+
+    >>> position_b = api.create(facility, "StoragePosition", title="Room B")
+    >>> position_b
+    <StoragePosition at /plone/senaite_storage/SF-00001/SP-00002>
+
+Move a container from one position to another:
+
+    >>> "/".join(nested_container.getPhysicalPath())
+    '/plone/senaite_storage/SF-00001/SP-00001/SC-00001/SC-00002'
+
+    >>> nested_container = api.move_object(nested_container, position_b, check_constraints=False)
+    >>> nested_container
+    <StorageContainer at /plone/senaite_storage/SF-00001/SP-00002/SC-00002>
+
+    >>> nested_container.aq_parent == position_b
+    True
+
+    >>> "/".join(nested_container.getPhysicalPath())
+    '/plone/senaite_storage/SF-00001/SP-00002/SC-00002'
+
+Move a container inside another container:
+
+    >>> another_container = api.create(position_b, "StorageContainer", title="Cabinet B")
+    >>> another_container
+    <StorageContainer at /plone/senaite_storage/SF-00001/SP-00002/SC-00003>
+
+    >>> nested_container = api.move_object(nested_container, another_container, check_constraints=False)
+    >>> nested_container
+    <StorageContainer at /plone/senaite_storage/SF-00001/SP-00002/SC-00003/SC-00002>
+
+    >>> nested_container.aq_parent == another_container
+    True
+
+
 StorageManager can create samples containers
 ............................................
 
@@ -268,6 +314,33 @@ And activate it again:
     'active'
 
 
+StorageManager can move samples containers
+..........................................
+
+The `move_container` transition is available for samples containers:
+
+    >>> "move_container" in getAllowedTransitions(samples_container)
+    True
+
+Samples containers can only be moved inside other containers. Check the current
+location of the samples container:
+
+    >>> "/".join(samples_container.getPhysicalPath())
+    '/plone/senaite_storage/SF-00001/SP-00001/SC-00001/SS-00001'
+
+Move the samples container to a different container:
+
+    >>> samples_container = api.move_object(samples_container, another_container, check_constraints=False)
+    >>> samples_container
+    <StorageSamplesContainer at /plone/senaite_storage/SF-00001/SP-00002/SC-00003/SS-00001>
+
+    >>> samples_container.aq_parent == another_container
+    True
+
+    >>> "/".join(samples_container.getPhysicalPath())
+    '/plone/senaite_storage/SF-00001/SP-00002/SC-00003/SS-00001'
+
+
 StorageManager can create full storage hierarchy
 ................................................
 
@@ -277,14 +350,14 @@ Create a complete storage hierarchy:
     >>> facility2
     <StorageFacility at /plone/senaite_storage/SF-00002>
 
-    >>> position2 = api.create(facility2, "StoragePosition", title="Room B")
+    >>> position2 = api.create(facility2, "StoragePosition", title="Room C")
     >>> position2
-    <StoragePosition at /plone/senaite_storage/SF-00002/SP-00002>
+    <StoragePosition at /plone/senaite_storage/SF-00002/SP-00003>
 
     >>> container2 = api.create(position2, "StorageContainer", title="Freezer 1")
     >>> container2
-    <StorageContainer at /plone/senaite_storage/SF-00002/SP-00002/SC-00003>
+    <StorageContainer at /plone/senaite_storage/SF-00002/SP-00003/SC-00004>
 
     >>> samples_container2 = api.create(container2, "StorageSamplesContainer", title="Box 1", Rows=3, Columns=3)
     >>> samples_container2
-    <StorageSamplesContainer at /plone/senaite_storage/SF-00002/SP-00002/SC-00003/SS-00002>
+    <StorageSamplesContainer at /plone/senaite_storage/SF-00002/SP-00003/SC-00004/SS-00002>

--- a/src/senaite/storage/tests/doctests/StoragePermissions.rst
+++ b/src/senaite/storage/tests/doctests/StoragePermissions.rst
@@ -1,0 +1,246 @@
+Storage Permissions
+-------------------
+
+Running this test from the buildout directory:
+
+    bin/test test_textual_doctests -t StoragePermissions
+
+Test Setup
+..........
+
+Needed Imports:
+
+    >>> from AccessControl.PermissionRole import rolesForPermissionOn
+    >>> from bika.lims import api
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> storage = portal.senaite_storage
+
+Create test objects as LabManager:
+
+    >>> setRoles(portal, TEST_USER_ID, ["LabManager"])
+    >>> facility = api.create(storage, "StorageFacility", title="Test Facility")
+    >>> position = api.create(facility, "StoragePosition", title="Room A")
+    >>> container = api.create(position, "StorageContainer", title="Freezer A")
+    >>> samples_container = api.create(container, "StorageSamplesContainer", title="Box A", Rows=3, Columns=3)
+
+
+Storage root folder permissions
+...............................
+
+The `Add portal content` permission in the storage root folder is granted to
+`StorageManager`:
+
+    >>> "StorageManager" in rolesForPermissionOn("Add portal content", storage)
+    True
+
+But `StorageAssistant` cannot add content to the storage root folder:
+
+    >>> "StorageAssistant" in rolesForPermissionOn("Add portal content", storage)
+    False
+
+The specific permission for adding facilities is granted to `StorageManager`:
+
+    >>> "StorageManager" in rolesForPermissionOn("senaite.storage: Add Storage Facility", storage)
+    True
+
+
+Facility permissions
+....................
+
+Inside a facility, both `StorageManager` and `StorageAssistant` have `Add portal
+content` permission (needed for creating positions and containers):
+
+    >>> "StorageManager" in rolesForPermissionOn("Add portal content", facility)
+    True
+
+    >>> "StorageAssistant" in rolesForPermissionOn("Add portal content", facility)
+    True
+
+Both roles can modify facility content:
+
+    >>> "StorageManager" in rolesForPermissionOn("Modify portal content", facility)
+    True
+
+    >>> "StorageAssistant" in rolesForPermissionOn("Modify portal content", facility)
+    True
+
+Both roles can view facilities:
+
+    >>> "StorageManager" in rolesForPermissionOn("View", facility)
+    True
+
+    >>> "StorageAssistant" in rolesForPermissionOn("View", facility)
+    True
+
+
+Position permissions
+....................
+
+Inside a position, both roles have `Add portal content` permission:
+
+    >>> "StorageManager" in rolesForPermissionOn("Add portal content", position)
+    True
+
+    >>> "StorageAssistant" in rolesForPermissionOn("Add portal content", position)
+    True
+
+Both roles can modify and view positions:
+
+    >>> "StorageManager" in rolesForPermissionOn("Modify portal content", position)
+    True
+
+    >>> "StorageAssistant" in rolesForPermissionOn("Modify portal content", position)
+    True
+
+    >>> "StorageManager" in rolesForPermissionOn("View", position)
+    True
+
+    >>> "StorageAssistant" in rolesForPermissionOn("View", position)
+    True
+
+
+Container permissions
+.....................
+
+Inside a container, both roles have `Add portal content` permission:
+
+    >>> "StorageManager" in rolesForPermissionOn("Add portal content", container)
+    True
+
+    >>> "StorageAssistant" in rolesForPermissionOn("Add portal content", container)
+    True
+
+Both roles can modify and view containers:
+
+    >>> "StorageManager" in rolesForPermissionOn("Modify portal content", container)
+    True
+
+    >>> "StorageAssistant" in rolesForPermissionOn("Modify portal content", container)
+    True
+
+    >>> "StorageManager" in rolesForPermissionOn("View", container)
+    True
+
+    >>> "StorageAssistant" in rolesForPermissionOn("View", container)
+    True
+
+
+Activate/Deactivate transition permissions
+..........................................
+
+Only `StorageManager` has the permission to activate and deactivate storage
+objects. `StorageAssistant` cannot activate or deactivate.
+
+Deactivate permission:
+
+    >>> "StorageManager" in rolesForPermissionOn("senaite.storage: Transition: Deactivate", facility)
+    True
+
+    >>> "StorageAssistant" in rolesForPermissionOn("senaite.storage: Transition: Deactivate", facility)
+    False
+
+Activate permission:
+
+    >>> "StorageManager" in rolesForPermissionOn("senaite.storage: Transition: Activate", facility)
+    True
+
+    >>> "StorageAssistant" in rolesForPermissionOn("senaite.storage: Transition: Activate", facility)
+    False
+
+The same applies to positions:
+
+    >>> "StorageManager" in rolesForPermissionOn("senaite.storage: Transition: Deactivate", position)
+    True
+
+    >>> "StorageAssistant" in rolesForPermissionOn("senaite.storage: Transition: Deactivate", position)
+    False
+
+And containers:
+
+    >>> "StorageManager" in rolesForPermissionOn("senaite.storage: Transition: Deactivate", container)
+    True
+
+    >>> "StorageAssistant" in rolesForPermissionOn("senaite.storage: Transition: Deactivate", container)
+    False
+
+
+Add/Recover Samples transition permissions
+..........................................
+
+Both `StorageManager` and `StorageAssistant` can add and recover samples from
+storage containers:
+
+    >>> "StorageManager" in rolesForPermissionOn("senaite.storage: Transition: Add Samples", samples_container)
+    True
+
+    >>> "StorageAssistant" in rolesForPermissionOn("senaite.storage: Transition: Add Samples", samples_container)
+    True
+
+    >>> "StorageManager" in rolesForPermissionOn("senaite.storage: Transition: Recover Samples", samples_container)
+    True
+
+    >>> "StorageAssistant" in rolesForPermissionOn("senaite.storage: Transition: Recover Samples", samples_container)
+    True
+
+
+Move Container transition permissions
+.....................................
+
+Both `StorageManager` and `StorageAssistant` can move containers:
+
+    >>> "StorageManager" in rolesForPermissionOn("senaite.storage: Transition: Move Container", container)
+    True
+
+    >>> "StorageAssistant" in rolesForPermissionOn("senaite.storage: Transition: Move Container", container)
+    True
+
+    >>> "StorageManager" in rolesForPermissionOn("senaite.storage: Transition: Move Container", samples_container)
+    True
+
+    >>> "StorageAssistant" in rolesForPermissionOn("senaite.storage: Transition: Move Container", samples_container)
+    True
+
+
+StorageAssistant cannot create facilities
+.........................................
+
+Users with only `StorageAssistant` role cannot create facilities in the storage
+root folder. They can only add content inside existing facilities.
+
+    >>> setRoles(portal, TEST_USER_ID, ["StorageAssistant"])
+
+Attempting to create a facility as StorageAssistant should raise Unauthorized:
+
+    >>> try:
+    ...     api.create(storage, "StorageFacility", title="Unauthorized Facility")
+    ... except Exception as e:
+    ...     print(e.__class__.__name__)
+    Unauthorized
+
+
+StorageAssistant can create positions and containers
+....................................................
+
+StorageAssistant can create positions inside facilities:
+
+    >>> new_position = api.create(facility, "StoragePosition", title="Room B")
+    >>> new_position.Title()
+    'Room B'
+
+StorageAssistant can create containers inside positions:
+
+    >>> new_container = api.create(new_position, "StorageContainer", title="Freezer B")
+    >>> new_container.Title()
+    'Freezer B'
+
+StorageAssistant can create samples containers inside containers:
+
+    >>> new_samples_container = api.create(new_container, "StorageSamplesContainer", title="Box B", Rows=2, Columns=2)
+    >>> new_samples_container.Title()
+    'Box B'

--- a/src/senaite/storage/tests/doctests/StoragePermissions.rst
+++ b/src/senaite/storage/tests/doctests/StoragePermissions.rst
@@ -21,6 +21,96 @@ Variables:
     >>> request = self.request
     >>> storage = portal.senaite_storage
 
+
+Portal-level permissions (site root)
+....................................
+
+When `senaite.storage` is installed, it adds storage-specific roles to existing
+permissions at the portal level WITHOUT removing roles assigned by other add-ons
+(e.g., `senaite.core`) and WITHOUT modifying the acquire setting.
+
+Helper to get roles with a permission granted for a given context:
+
+    >>> def get_roles_for_permission(context, permission):
+    ...     roles = filter(lambda p: p.get("selected") == "SELECTED",
+    ...                    context.rolesOfPermission(permission))
+    ...     return sorted([r["name"] for r in roles])
+
+Helper to check if acquire is enabled for a permission:
+
+    >>> def is_acquire_enabled(context, permission):
+    ...     return context.acquiredRolesAreUsedBy(permission) == "CHECKED"
+
+The `View` permission at the portal level has storage roles added, while
+preserving roles from other add-ons (e.g., `Analyst` from `senaite.core`):
+
+    >>> roles = get_roles_for_permission(portal, "View")
+    >>> "StorageManager" in roles
+    True
+    >>> "StorageAssistant" in roles
+    True
+    >>> "LabManager" in roles
+    True
+    >>> "LabClerk" in roles
+    True
+    >>> "Analyst" in roles
+    True
+
+The `Access contents information` permission has storage roles added while
+preserving existing roles:
+
+    >>> roles = get_roles_for_permission(portal, "Access contents information")
+    >>> "StorageManager" in roles
+    True
+    >>> "StorageAssistant" in roles
+    True
+    >>> "LabManager" in roles
+    True
+    >>> "LabClerk" in roles
+    True
+    >>> "Analyst" in roles
+    True
+
+The `List folder contents` permission has storage roles added while preserving
+existing roles:
+
+    >>> roles = get_roles_for_permission(portal, "List folder contents")
+    >>> "StorageManager" in roles
+    True
+    >>> "StorageAssistant" in roles
+    True
+    >>> "LabManager" in roles
+    True
+    >>> "LabClerk" in roles
+    True
+    >>> "Analyst" in roles
+    True
+    >>> "Manager" in roles
+    True
+
+The `senaite.core: Manage Analysis Requests` permission has storage roles added
+while preserving core roles (e.g., `LabManager`, `LabClerk`):
+
+    >>> roles = get_roles_for_permission(portal, "senaite.core: Manage Analysis Requests")
+    >>> "StorageManager" in roles
+    True
+    >>> "StorageAssistant" in roles
+    True
+    >>> "LabManager" in roles
+    True
+    >>> "LabClerk" in roles
+    True
+
+The acquire setting is preserved for these permissions. For instance, `View` at
+the portal level has acquire enabled and it remains enabled after installation:
+
+    >>> is_acquire_enabled(portal, "View")
+    True
+
+    >>> is_acquire_enabled(portal, "Access contents information")
+    True
+
+
 Create test objects as LabManager:
 
     >>> setRoles(portal, TEST_USER_ID, ["LabManager"])

--- a/src/senaite/storage/upgrade/v02_07_000.py
+++ b/src/senaite/storage/upgrade/v02_07_000.py
@@ -472,7 +472,7 @@ def setup_storage_roles_and_groups(tool):
     logger.info("Updating role mappings of storage objects ...")
     workflow = wapi.get_workflow(STORAGE_WORKFLOW_ID)
     cat = api.get_tool(STORAGE_CATALOG)
-    brains = [] # cat()
+    brains = cat()
     total = len(brains)
     for num, brain in enumerate(brains):
         if num and num % 100 == 0:
@@ -489,7 +489,7 @@ def setup_storage_roles_and_groups(tool):
     logger.info("Updating role mappings of samples ...")
     workflow = wapi.get_workflow(SAMPLE_WORKFLOW)
     cat = api.get_tool(SAMPLE_CATALOG)
-    brains = cat(review_state="stored", sort_limit=1000)
+    brains = cat(review_state="stored")
     total = len(brains)
     for num, brain in enumerate(brains):
         if num and num % 100 == 0:

--- a/src/senaite/storage/upgrade/v02_07_000.py
+++ b/src/senaite/storage/upgrade/v02_07_000.py
@@ -18,19 +18,26 @@
 # Copyright 2019-2024 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from bika.lims.utils import tmpID
 from bika.lims import api
+from bika.lims.utils import tmpID
 from plone.dexterity.fti import DexterityFTI
 from plone.dexterity.utils import createContent
+from senaite.core.api import workflow as wapi
 from senaite.core.interfaces import IContentMigrator
 from senaite.core.schema.addressfield import PHYSICAL_ADDRESS
 from senaite.core.upgrade import upgradestep
 from senaite.core.upgrade.utils import UpgradeUtils
-from senaite.storage import PRODUCT_NAME
+from senaite.core.workflow import SAMPLE_WORKFLOW
 from senaite.storage import logger
+from senaite.storage import PRODUCT_NAME
 from senaite.storage.catalog import STORAGE_CATALOG
+from senaite.storage.config import STORAGE_WORKFLOW_ID
 from senaite.storage.setuphandlers import display_in_nav
+from senaite.storage.setuphandlers import setup_user_groups
+from senaite.storage.setuphandlers import setup_workflows
 from zope.component import getMultiAdapter
+from senaite.core.catalog import SAMPLE_CATALOG
+import transaction
 
 version = "2.7.0"
 profile = "profile-{0}:default".format(PRODUCT_NAME)
@@ -425,3 +432,84 @@ def display_storage_navbar(tool):
     portal = api.get_portal()
     display_in_nav(portal.senaite_storage)
     logger.info("Display storage in navigation bar [DONE]")
+
+
+@upgradestep(PRODUCT_NAME, version)
+def setup_storage_roles_and_groups(tool):
+    """Set up storage-specific roles and user groups.
+
+    We add the @upgradestep decorator because we reapply storage-specific
+    workflow changes in `setuphandlers.update_workflow`, which may otherwise
+    overwrite workflow customizations introduced by more specific add-ons.
+    Using this decorator ensures that upgrade subscribers from other add-ons
+    are executed afterwards.
+    """
+    logger.info("Setup storage-specific roles and groups ...")
+
+    portal = tool.aq_inner.aq_parent
+    setup = portal.portal_setup  # noqa
+
+    # import rolemap and workflow definitions
+    setup.runImportStepFromProfile(profile, "rolemap")
+    setup.runImportStepFromProfile(profile, "workflow")
+
+    # setup user groups
+    setup_user_groups(portal)
+
+    # setup workflows
+    setup_workflows(portal)
+
+    # catalog indexes to reindex after updating role mappings
+    idxs = ["allowedRolesAndUsers"]
+
+    # update role mappings for storage's root folder
+    storage_folder = portal.senaite_storage
+    workflow = wapi.get_workflow("senaite_storage_folder_workflow")
+    workflow.updateRoleMappingsFor(storage_folder)
+    storage_folder.reindexObject(idxs=idxs)
+
+    # update role mappings for storage-specific objects
+    logger.info("Updating role mappings of storage objects ...")
+    workflow = wapi.get_workflow(STORAGE_WORKFLOW_ID)
+    cat = api.get_tool(STORAGE_CATALOG)
+    brains = [] # cat()
+    total = len(brains)
+    for num, brain in enumerate(brains):
+        if num and num % 100 == 0:
+            logger.info("Updating role mappings of storage objects {0}/{1}"
+                        .format(num, total))
+            transaction.savepoint(optimistic=True)
+
+        ob = api.get_object(brain)
+        workflow.updateRoleMappingsFor(ob)
+        cat.catalog_object(ob, idxs=idxs, update_metadata=0)
+        ob._p_deactivate()  # noqa
+
+    # update role mappings for samples in 'stored' status
+    logger.info("Updating role mappings of samples ...")
+    workflow = wapi.get_workflow(SAMPLE_WORKFLOW)
+    cat = api.get_tool(SAMPLE_CATALOG)
+    brains = cat(review_state="stored", sort_limit=1000)
+    total = len(brains)
+    for num, brain in enumerate(brains):
+        if num and num % 100 == 0:
+            logger.info("Updating role mappings of samples {0}/{1}"
+                        .format(num, total))
+            transaction.savepoint(optimistic=True)
+
+        if num and num % 1000 == 0:
+            # Updating role mappings on samples can exhaust all available RAM,
+            # even if objects are explicitly deactivated. This happens because
+            # DCWorkflow's updateRoleMappings wakes up objects across the
+            # entire hierarchy in order to resolve inherited permissions via
+            # acquisition. Therefore, we deactivate here all unmodified objects
+            # from the cache of the current database connection
+            logger.info("Flushing deactivated objects from cache ...")
+            api.get_portal()._p_jar.cacheMinimize()  # noqa
+
+        ob = api.get_object(brain)
+        workflow.updateRoleMappingsFor(ob)
+        cat.catalog_object(ob, idxs=idxs, update_metadata=0)
+        ob._p_deactivate()  # noqa
+
+    logger.info("Setup storage-specific roles and groups [DONE]")

--- a/src/senaite/storage/upgrade/v02_07_000.py
+++ b/src/senaite/storage/upgrade/v02_07_000.py
@@ -33,6 +33,7 @@ from senaite.storage import PRODUCT_NAME
 from senaite.storage.catalog import STORAGE_CATALOG
 from senaite.storage.config import STORAGE_WORKFLOW_ID
 from senaite.storage.setuphandlers import display_in_nav
+from senaite.storage.setuphandlers import setup_roles
 from senaite.storage.setuphandlers import setup_user_groups
 from senaite.storage.setuphandlers import setup_workflows
 from zope.component import getMultiAdapter
@@ -452,6 +453,9 @@ def setup_storage_roles_and_groups(tool):
     # import rolemap and workflow definitions
     setup.runImportStepFromProfile(profile, "rolemap")
     setup.runImportStepFromProfile(profile, "workflow")
+
+    # setup roles permissions for portal
+    setup_roles(portal)
 
     # setup user groups
     setup_user_groups(portal)

--- a/src/senaite/storage/upgrade/v02_07_000.py
+++ b/src/senaite/storage/upgrade/v02_07_000.py
@@ -505,7 +505,7 @@ def setup_storage_roles_and_groups(tool):
             # acquisition. Therefore, we deactivate here all unmodified objects
             # from the cache of the current database connection
             logger.info("Flushing deactivated objects from cache ...")
-            api.get_portal()._p_jar.cacheMinimize()  # noqa
+            portal._p_jar.cacheMinimize()  # noqa
 
         ob = api.get_object(brain)
         workflow.updateRoleMappingsFor(ob)

--- a/src/senaite/storage/upgrade/v02_07_000.zcml
+++ b/src/senaite/storage/upgrade/v02_07_000.zcml
@@ -3,6 +3,16 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="Setup new storage-specific groups and roles"
+      description="
+        This upgrade step creates the roles 'Storage Manager' and 'Storage
+        Assistant', along with their counterpart user groups."
+      source="2705"
+      destination="2706"
+      handler=".v02_07_000.setup_storage_roles_and_groups"
+      profile="senaite.storage:default"/>
+
+  <genericsetup:upgradeStep
       title="Display Storage in navigation bar"
       description="
         This upgrade step makes the product compatible with senaite.core#2835


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds two additional roles with storage-specific permissions:

**StorageManager**
- [x] Create and deactivate facilities and storage locations
- [x] Create, move and deactivate containers and sample containers
- [x] Store and retrieve samples in/from storage

**StorageAssistant**
- [x] Create and move sample containers
- [x] Store, retrieve and discard samples in storage

Two groups (one per each role) are added too.

## Current behavior before PR

No storage-specific roles are present

## Desired behavior after PR is merged

Storage-specific roles are present

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
