### PR TITLE
Add 'Storage Expiry Date' column in samples listing, under 'Stored' filter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #64 Add 'Storage Expiry Date' column in samples listing, under 'Stored'
 - #62 Add configurable storage retention period
 - #61 Added StorageManager and StorageAssistant roles and counterpart groups
 - #60 Fix sample search when assigning received samples to storage container

--- a/src/senaite/storage/adapters/listing.py
+++ b/src/senaite/storage/adapters/listing.py
@@ -26,6 +26,7 @@ from senaite.storage import is_installed
 from senaite.storage import senaiteMessageFactory as _
 from zope.component import adapts
 from zope.interface import implementer
+from senaite.core.api import dtime
 
 
 @implementer(IListingViewAdapter)
@@ -117,27 +118,43 @@ class AnalysisRequestsListingViewAdapter(object):
                              column_values, after="getDateStored",
                              review_states=("stored", ))
 
+        # Add expiry date column
+        utils.add_column(
+            self.listing,
+            column_id="getStorageExpiryDate",
+            column_values=dict(
+                title=_("Storage Expiry Date"),
+                toggle=True,
+            ),
+            after="getDateStored",
+            review_states=("stored", )
+        )
+
     def folder_item(self, obj, item, index):
         # Return immediately when add-on is not installed
         if not self.installed:
             return item
 
-        # Ingore partitions and add column
-        if self.is_stored_state():
-            # Show the date time when the sample was stored
-            item["getDateStored"] = self.str_time(obj.getDateStored)
+        # Return immediately if sample is not stored
+        if not self.is_stored_state():
+            return item
 
-        # Display all samples in "flat style"
-        if self.flat_listing:
-            item["parent"] = ""
-            item["children"] = []
+        # date time when the sample was stored
+        stored_date = dtime.to_localized_time(obj.getDateStored, long_format=1)
+        item["getDateStored"] = stored_date
+
+        # date when the retention period expires
+        obj = api.get_object(obj)
+        expiry_date = obj.getStorageExpiryDate()
+        item["getStorageExpiryDate"] = dtime.to_localized_time(expiry_date)
+
+        # display in red if retention expired
+        if expiry_date <= dtime.DateTime():
+            expiry = dtime.to_localized_time(expiry_date)
+            span = "<span class='text-danger'>%s</span>" % expiry
+            item["replace"]["getStorageExpiryDate"] = span
 
         return item
-
-    def str_time(self, date_time, long_format=1):
-        """Returns a string representation of localized DateTime
-        """
-        return self.listing.ulocalized_time(date_time, long_format=long_format)
 
     def is_stored_state(self):
         """Returns whether the current review state of the listing is "stored"

--- a/src/senaite/storage/browser/container/samples.py
+++ b/src/senaite/storage/browser/container/samples.py
@@ -156,6 +156,7 @@ class SampleListingView(ListingView):
             item["PreviousState"] = self.translate_review_state(
                 prev_state, api.get_portal_type(obj))
 
+        return item
         # storage expiry date
         column = "getStorageExpiryDate"
         expiry_date = obj.getStorageExpiryDate()

--- a/src/senaite/storage/browser/container/samples.py
+++ b/src/senaite/storage/browser/container/samples.py
@@ -156,7 +156,6 @@ class SampleListingView(ListingView):
             item["PreviousState"] = self.translate_review_state(
                 prev_state, api.get_portal_type(obj))
 
-        return item
         # storage expiry date
         column = "getStorageExpiryDate"
         expiry_date = obj.getStorageExpiryDate()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds an "Expiry Date" column in samples listing, but only under "stored" filter:

<img width="1693" height="362" alt="20260221124330" src="https://github.com/user-attachments/assets/edd536b8-d3cf-4c32-9dd4-0eaf3c8772df" />


Also, the expiry date is displayed in red if is after current date.

## Current behavior before PR

Storage Expiry Date column is present in samples listing (under "Stored" filter)

## Desired behavior after PR is merged

Storage Expiry Date column is not present in samples listing (under "Stored" filter)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
