### PR TITLE
Add a "Past Retention" filter in samples listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #65 Add a "Past Retention" filter in samples listing
 - #63 Result type-specific controls in retention rules settings
 - #64 Add 'Storage Expiry Date' column in samples listing, under 'Stored'
 - #62 Add configurable storage retention period

--- a/src/senaite/storage/adapters/listing.py
+++ b/src/senaite/storage/adapters/listing.py
@@ -18,20 +18,113 @@
 # Copyright 2019-2024 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import copy
+
 from bika.lims import api
+from bika.lims import senaiteMessageFactory as _s
 from senaite.app.listing import utils
 from senaite.app.listing.interfaces import IListingView
 from senaite.app.listing.interfaces import IListingViewAdapter
+from senaite.core.api import dtime
 from senaite.storage import is_installed
 from senaite.storage import senaiteMessageFactory as _
-from zope.component import adapts
+from zope.component import adapter
 from zope.interface import implementer
-from senaite.core.api import dtime
+
+HIDE_COLUMNS = (
+    "getAnalysesNum",
+    "getDateVerified",
+    "getDatePreserved",
+    "getDatePublished",
+    "getDueDate",
+    "getStorageLocation",
+    "Printed"
+    "Progress",
+    "SamplingDate",
+)
+
+ADD_COLUMNS = (
+    {
+        "id": "getDateStored",
+        "title": _(
+            u"listing_samples_column_date_stored",
+            default=u"Date stored"
+        ),
+        "index": "getDateStored",
+        "toggle": True,
+        "after": "getDateReceived",
+        "review_states": ("stored", "past_retention"),
+    },
+    {
+        "id": "getStorageExpiryDate",
+        "title": _(
+            u"listing_samples_column_storage_expiry_date",
+            default=u"Storage expiry date"
+        ),
+        "toggle": True,
+        "after": "getDateStored",
+        "review_states": ("stored", "past_retention"),
+    },
+    {
+        "id": "getSamplesContainer",
+        "title": _(
+            u"listing_samples_column_storage",
+            default=u"Storage"
+        ),
+        "attr": "getSamplesContainerID",
+        "replace_url": "getSamplesContainerURL",
+        "toggle": True,
+        "after": "getDateStored",
+        "review_states": ("stored", "past_retention"),
+        "condition": "is_lab_user",
+    }
+)
+
+ADD_CUSTOM_TRANSITIONS = (
+    {
+        "id": "print_stickers",
+        "title": _s("Print stickers"),
+        "url": "workflow_action?action=print_stickers",
+        "review_states": ("stored", "past_retention")
+    },
+)
+
+ADD_REVIEW_STATES = (
+    {
+        "id": "stored",
+        "title": _(
+            u"listing_samples_state_stored",
+            default=u"Stored"
+        ),
+        "contentFilter": {
+            "review_state": ("stored",),
+            "sort_on": "created",
+            "sort_order": "descending",
+        },
+        "confirm_transitions": ["recover"],
+        "after": "published",
+    },
+    {
+        "id": "past_retention",
+        "title": _(
+            u"listing_samples_state_past_retention",
+            default=u"Past Retention"
+        ),
+        "contentFilter": {
+            "review_state": ("stored",),
+            "sort_on": "getDateStored",
+            "sort_order": "descending",
+        },
+        "transitions": [],
+        "confirm_transitions": ["recover"],
+        "after": "stored",
+    },
+)
 
 
+@adapter(IListingView)
 @implementer(IListingViewAdapter)
 class AnalysisRequestsListingViewAdapter(object):
-    adapts(IListingView)
 
     # Order of priority of this subscriber adapter over others
     priority_order = 10
@@ -47,88 +140,68 @@ class AnalysisRequestsListingViewAdapter(object):
         if not self.installed:
             return
 
-        # Add review state "stored" in the listing
-        self.add_stored_review_state()
+        # Additional filters/review statuses
+        map(self.add_review_state, ADD_REVIEW_STATES)
+
+        # Additional columns
+        map(self.add_column, ADD_COLUMNS)
+
+        # Additional custom transitions
+        map(self.add_custom_transition, ADD_CUSTOM_TRANSITIONS)
 
         # In "stored" status, display all samples in "flat style"
         if self.is_stored_state():
             self.flat_listing = True
             self.listing.contentFilter.pop("isRootAncestor", None)
 
-    def add_stored_review_state(self):
-        """Adds the "stored" review state to the listing's review_states pool
+    def add_review_state(self, state_info):
+        """Adds the review state with the provided information
         """
-        # Columns to hide
-        hide = [
-            "getAnalysesNum",
-            "getDateVerified",
-            "getDatePreserved",
-            "getDatePublished",
-            "getDueDate",
-            "getStorageLocation",
-            "Printed"
-            "Progress",
-            "SamplingDate",
-        ]
-        columns = filter(lambda c: c not in hide, self.listing.columns.keys())
+        info = copy.deepcopy(state_info)
+        after = info.pop("after", None)
+        cols = info.pop("columns", None)
+        if not cols:
+            cols = self.listing.columns.keys()
+            cols = list(filter(lambda col: col not in HIDE_COLUMNS, cols))
+        info["columns"] = cols
+        utils.add_review_state(self.listing, info, after=after)
 
-        # Custom transitions
-        print_stickers = {
-            "id": "print_stickers",
-            "title": _("Print stickers"),
-            "url": "workflow_action?action=print_stickers"
-        }
+    def add_column(self, column_info):
+        """Adds the column with the provided information
+        """
+        info = copy.deepcopy(column_info)
+        condition = info.pop("condition", None)
+        if condition and not getattr(self, condition)():
+            # do not add the column if condition is not met
+            return
 
-        # "stored" review state
-        stored = {
-            "id": "stored",
-            "title": _("Stored"),
-            "contentFilter": {
-                "review_state": ("stored",),
-                "sort_on": "created",
-                "sort_order": "descending",
-            },
-            "transitions": [],
-            "custom_transitions": [print_stickers],
-            "confirm_transitions": ["recover"],
-            "columns": columns,
-        }
+        column_id = info.pop("id")
+        after = info.pop("after", None)
+        review_states = info.pop("review_states", None)
+        if review_states is None:
+            review_states = [st["id"] for st in self.listing.review_states]
 
-        # Add the review state
-        utils.add_review_state(self.listing, stored, after="published")
+        utils.add_column(listing=self.listing,
+                         column_id=column_id,
+                         column_values=info,
+                         after=after,
+                         review_states=review_states)
 
-        # Add the column "DateStored" to "stored" review_state
-        column_values = {
-            "title": _("Date stored"),
-            "index": "getDateStored",
-            "toggle": True}
-        utils.add_column(self.listing, "getDateStored", column_values,
-                         after="getDateReceived", review_states=("stored",))
+    def add_custom_transition(self, transition_info):
+        """Adds a custom transition for the given statuses
+        """
+        info = copy.deepcopy(transition_info)
+        statuses = info.pop("review_states")
+        rss = filter(lambda a: a["id"] in statuses, self.listing.review_states)
+        for rs in rss:
+            rs.setdefault("custom_transitions", []).append(info)
 
-        # Add Samples Container column, but only if the current user logged in
-        # is not a client contact
-        if not api.get_current_client():
-            column_values = {
-                "title": _("Storage"),
-                "attr": "getSamplesContainerID",
-                "replace_url": "getSamplesContainerURL",
-                "toggle": True
-            }
-            utils.add_column(self.listing, "getSamplesContainer",
-                             column_values, after="getDateStored",
-                             review_states=("stored", ))
-
-        # Add expiry date column
-        utils.add_column(
-            self.listing,
-            column_id="getStorageExpiryDate",
-            column_values=dict(
-                title=_("Storage Expiry Date"),
-                toggle=True,
-            ),
-            after="getDateStored",
-            review_states=("stored", )
-        )
+    def is_lab_user(self):
+        """Returns whether the current user is not from a client
+        """
+        if api.get_current_client():
+            return False
+        return True
 
     def folder_item(self, obj, item, index):
         # Return immediately when add-on is not installed
@@ -162,4 +235,5 @@ class AnalysisRequestsListingViewAdapter(object):
         review_state = self.listing.review_state
         if not review_state:
             return False
-        return review_state.get("id", "") == "stored"
+        statuses = [st["id"] for st in ADD_REVIEW_STATES]
+        return review_state.get("id", "") in statuses

--- a/src/senaite/storage/adapters/listing.py
+++ b/src/senaite/storage/adapters/listing.py
@@ -59,7 +59,7 @@ ADD_COLUMNS = (
         "id": "getStorageExpiryDate",
         "title": _(
             u"listing_samples_column_storage_expiry_date",
-            default=u"Storage expiry date"
+            default=u"Retain Until"
         ),
         "index": "getStorageExpiryDate",
         "toggle": True,

--- a/src/senaite/storage/adapters/listing.py
+++ b/src/senaite/storage/adapters/listing.py
@@ -61,6 +61,7 @@ ADD_COLUMNS = (
             u"listing_samples_column_storage_expiry_date",
             default=u"Storage expiry date"
         ),
+        "index": "getStorageExpiryDate",
         "toggle": True,
         "after": "getDateStored",
         "review_states": ("stored", "past_retention"),
@@ -112,7 +113,7 @@ ADD_REVIEW_STATES = (
         ),
         "contentFilter": {
             "review_state": ("stored",),
-            "sort_on": "getDateStored",
+            "sort_on": "getStorageExpiryDate",
             "sort_order": "descending",
         },
         "transitions": [],
@@ -153,6 +154,17 @@ class AnalysisRequestsListingViewAdapter(object):
         if self.is_stored_state():
             self.flat_listing = True
             self.listing.contentFilter.pop("isRootAncestor", None)
+
+        # Update the contentFilter of the "past_retention" filter, so only
+        # stored samples whose retention period has passed are displayed
+        for rv in self.listing.review_states:
+            if rv.get("id") == "past_retention":
+                rv["contentFilter"].update({
+                    "getStorageExpiryDate": {
+                        "query": dtime.DateTime(),
+                        "range": "max",
+                    }
+                })
 
     def add_review_state(self, state_info):
         """Adds the review state with the provided information

--- a/src/senaite/storage/profiles/default/metadata.xml
+++ b/src/senaite/storage/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>2707</version>
+  <version>2708</version>
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>
     <dependency>profile-senaite.lims:default</dependency>

--- a/src/senaite/storage/setuphandlers.py
+++ b/src/senaite/storage/setuphandlers.py
@@ -86,6 +86,7 @@ CATALOG_MAPPINGS = [
 INDEXES = [
     # Index used in ARs view to sort items by date stored by default
     (SAMPLE_CATALOG, "getDateStored", "", "DateIndex"),
+    (SAMPLE_CATALOG, "getStorageExpiryDate", "", "DateIndex"),
 ]
 
 # Tuples of (catalog, column name)

--- a/src/senaite/storage/upgrade/v02_07_000.py
+++ b/src/senaite/storage/upgrade/v02_07_000.py
@@ -25,6 +25,7 @@ from plone.dexterity.utils import createContent
 from senaite.core.api import workflow as wapi
 from senaite.core.interfaces import IContentMigrator
 from senaite.core.schema.addressfield import PHYSICAL_ADDRESS
+from senaite.core.setuphandlers import add_catalog_index
 from senaite.core.upgrade import upgradestep
 from senaite.core.upgrade.utils import UpgradeUtils
 from senaite.core.workflow import SAMPLE_WORKFLOW
@@ -529,3 +530,29 @@ def setup_retention_period_rules(tool):
     setup.runImportStepFromProfile(profile, "plone.app.registry")
 
     logger.info("Setup retention period rules [DONE]")
+
+
+def setup_past_retention_filter(tool):
+    """Adds a DateIndex in samples catalog ('getStorageExpiryDate') to allow
+    date range searches by retention period expiry date
+    """
+    logger.info("Setup past retention filter ...")
+    portal = tool.aq_inner.aq_parent
+
+    # Add the index (without reindex)
+    cat = api.get_tool(SAMPLE_CATALOG)
+    idx_id = "getStorageExpiryDate"
+    add_catalog_index(cat, idx_id, "", "DateIndex")
+
+    # reindex this index only for samples in stored status
+    brains = cat(review_state="stored")
+    total = len(brains)
+    for num, brain in enumerate(brains):
+        if num and num % 100 == 0:
+            logger.info("Processed objects: {0}/{1}".format(num, total))
+
+        obj = api.get_object(brain)
+        obj.reindexObject(idxs=[idx_id])
+        obj._p_deactivate()
+
+    logger.info("Setup past retention filter [DONE]")

--- a/src/senaite/storage/upgrade/v02_07_000.py
+++ b/src/senaite/storage/upgrade/v02_07_000.py
@@ -550,6 +550,7 @@ def setup_past_retention_filter(tool):
     for num, brain in enumerate(brains):
         if num and num % 100 == 0:
             logger.info("Processed objects: {0}/{1}".format(num, total))
+            transaction.savepoint()
 
         obj = api.get_object(brain)
         obj.reindexObject(idxs=[idx_id])

--- a/src/senaite/storage/upgrade/v02_07_000.zcml
+++ b/src/senaite/storage/upgrade/v02_07_000.zcml
@@ -3,6 +3,17 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="Add 'Past Retention' filter in samples listing"
+      description="
+        Adds a 'Past Retention' filter in samples listing and a DateIndex in
+        samples catalog ('getStorageExpiryDate') to allow date range searches
+        by retention period expiry date."
+      source="2707"
+      destination="2708"
+      handler=".v02_07_000.setup_past_retention_filter"
+      profile="senaite.storage:default"/>
+
+  <genericsetup:upgradeStep
       title="Setup retention period rules"
       description="
         Register retention period rules field in the registry for


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds a filter button "Past retention" in samples listing that, when clicked, only stored samples whose retention period has passed are displayed.

<img width="1841" height="311" alt="20260307072141" src="https://github.com/user-attachments/assets/469ea1de-104e-4aa0-9581-2e34b4b4a7cf" />

## Current behavior before PR

There is no specific filter button to only display stored samples whose retention period has passed

## Desired behavior after PR is merged

There is specific filter button to only display stored samples whose retention period has passed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
