### PR TITLE
Add visual warning for samples approaching retention expiration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #65 Add a "Past Retention" filter in samples listing
 - #63 Result type-specific controls in retention rules settings
 - #64 Add 'Storage Expiry Date' column in samples listing, under 'Stored'
 - #62 Add configurable storage retention period

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #66 Add visual warning for samples approaching retention expiration
 - #65 Add a "Past Retention" filter in samples listing
 - #63 Result type-specific controls in retention rules settings
 - #64 Add 'Storage Expiry Date' column in samples listing, under 'Stored'

--- a/src/senaite/storage/adapters/listing.py
+++ b/src/senaite/storage/adapters/listing.py
@@ -18,20 +18,113 @@
 # Copyright 2019-2024 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import copy
+
 from bika.lims import api
+from bika.lims import senaiteMessageFactory as _s
 from senaite.app.listing import utils
 from senaite.app.listing.interfaces import IListingView
 from senaite.app.listing.interfaces import IListingViewAdapter
+from senaite.core.api import dtime
 from senaite.storage import is_installed
 from senaite.storage import senaiteMessageFactory as _
-from zope.component import adapts
+from zope.component import adapter
 from zope.interface import implementer
-from senaite.core.api import dtime
+
+HIDE_COLUMNS = (
+    "getAnalysesNum",
+    "getDateVerified",
+    "getDatePreserved",
+    "getDatePublished",
+    "getDueDate",
+    "getStorageLocation",
+    "Printed"
+    "Progress",
+    "SamplingDate",
+)
+
+ADD_COLUMNS = (
+    {
+        "id": "getDateStored",
+        "title": _(
+            u"listing_samples_column_date_stored",
+            default=u"Date stored"
+        ),
+        "index": "getDateStored",
+        "toggle": True,
+        "after": "getDateReceived",
+        "review_states": ("stored", "past_retention"),
+    },
+    {
+        "id": "getStorageExpiryDate",
+        "title": _(
+            u"listing_samples_column_storage_expiry_date",
+            default=u"Storage expiry date"
+        ),
+        "toggle": True,
+        "after": "getDateStored",
+        "review_states": ("stored", "past_retention"),
+    },
+    {
+        "id": "getSamplesContainer",
+        "title": _(
+            u"listing_samples_column_storage",
+            default=u"Storage"
+        ),
+        "attr": "getSamplesContainerID",
+        "replace_url": "getSamplesContainerURL",
+        "toggle": True,
+        "after": "getDateStored",
+        "review_states": ("stored", "past_retention"),
+        "condition": "is_lab_user",
+    }
+)
+
+ADD_CUSTOM_TRANSITIONS = (
+    {
+        "id": "print_stickers",
+        "title": _s("Print stickers"),
+        "url": "workflow_action?action=print_stickers",
+        "review_states": ("stored", "past_retention")
+    },
+)
+
+ADD_REVIEW_STATES = (
+    {
+        "id": "stored",
+        "title": _(
+            u"listing_samples_state_stored",
+            default=u"Stored"
+        ),
+        "contentFilter": {
+            "review_state": ("stored",),
+            "sort_on": "created",
+            "sort_order": "descending",
+        },
+        "confirm_transitions": ["recover"],
+        "after": "published",
+    },
+    {
+        "id": "past_retention",
+        "title": _(
+            u"listing_samples_state_past_retention",
+            default=u"Past Retention"
+        ),
+        "contentFilter": {
+            "review_state": ("stored",),
+            "sort_on": "getDateStored",
+            "sort_order": "descending",
+        },
+        "transitions": [],
+        "confirm_transitions": ["recover"],
+        "after": "stored",
+    },
+)
 
 
+@adapter(IListingView)
 @implementer(IListingViewAdapter)
 class AnalysisRequestsListingViewAdapter(object):
-    adapts(IListingView)
 
     # Order of priority of this subscriber adapter over others
     priority_order = 10
@@ -47,88 +140,68 @@ class AnalysisRequestsListingViewAdapter(object):
         if not self.installed:
             return
 
-        # Add review state "stored" in the listing
-        self.add_stored_review_state()
+        # Additional filters/review statuses
+        map(self.add_review_state, ADD_REVIEW_STATES)
+
+        # Additional columns
+        map(self.add_column, ADD_COLUMNS)
+
+        # Additional custom transitions
+        map(self.add_custom_transition, ADD_CUSTOM_TRANSITIONS)
 
         # In "stored" status, display all samples in "flat style"
         if self.is_stored_state():
             self.flat_listing = True
             self.listing.contentFilter.pop("isRootAncestor", None)
 
-    def add_stored_review_state(self):
-        """Adds the "stored" review state to the listing's review_states pool
+    def add_review_state(self, state_info):
+        """Adds the review state with the provided information
         """
-        # Columns to hide
-        hide = [
-            "getAnalysesNum",
-            "getDateVerified",
-            "getDatePreserved",
-            "getDatePublished",
-            "getDueDate",
-            "getStorageLocation",
-            "Printed"
-            "Progress",
-            "SamplingDate",
-        ]
-        columns = filter(lambda c: c not in hide, self.listing.columns.keys())
+        info = copy.deepcopy(state_info)
+        after = info.pop("after", None)
+        cols = info.pop("columns", None)
+        if not cols:
+            cols = self.listing.columns.keys()
+            cols = list(filter(lambda col: col not in HIDE_COLUMNS, cols))
+        info["columns"] = cols
+        utils.add_review_state(self.listing, info, after=after)
 
-        # Custom transitions
-        print_stickers = {
-            "id": "print_stickers",
-            "title": _("Print stickers"),
-            "url": "workflow_action?action=print_stickers"
-        }
+    def add_column(self, column_info):
+        """Adds the column with the provided information
+        """
+        info = copy.deepcopy(column_info)
+        condition = info.pop("condition", None)
+        if condition and not getattr(self, condition)():
+            # do not add the column if condition is not met
+            return
 
-        # "stored" review state
-        stored = {
-            "id": "stored",
-            "title": _("Stored"),
-            "contentFilter": {
-                "review_state": ("stored",),
-                "sort_on": "created",
-                "sort_order": "descending",
-            },
-            "transitions": [],
-            "custom_transitions": [print_stickers],
-            "confirm_transitions": ["recover"],
-            "columns": columns,
-        }
+        column_id = info.pop("id")
+        after = info.pop("after", None)
+        review_states = info.pop("review_states", None)
+        if review_states is None:
+            review_states = [st["id"] for st in self.listing.review_states]
 
-        # Add the review state
-        utils.add_review_state(self.listing, stored, after="published")
+        utils.add_column(listing=self.listing,
+                         column_id=column_id,
+                         column_values=info,
+                         after=after,
+                         review_states=review_states)
 
-        # Add the column "DateStored" to "stored" review_state
-        column_values = {
-            "title": _("Date stored"),
-            "index": "getDateStored",
-            "toggle": True}
-        utils.add_column(self.listing, "getDateStored", column_values,
-                         after="getDateReceived", review_states=("stored",))
+    def add_custom_transition(self, transition_info):
+        """Adds a custom transition for the given statuses
+        """
+        info = copy.deepcopy(transition_info)
+        statuses = info.pop("review_states")
+        rss = filter(lambda a: a["id"] in statuses, self.listing.review_states)
+        for rs in rss:
+            rs.setdefault("custom_transitions", []).append(info)
 
-        # Add Samples Container column, but only if the current user logged in
-        # is not a client contact
-        if not api.get_current_client():
-            column_values = {
-                "title": _("Storage"),
-                "attr": "getSamplesContainerID",
-                "replace_url": "getSamplesContainerURL",
-                "toggle": True
-            }
-            utils.add_column(self.listing, "getSamplesContainer",
-                             column_values, after="getDateStored",
-                             review_states=("stored", ))
-
-        # Add expiry date column
-        utils.add_column(
-            self.listing,
-            column_id="getStorageExpiryDate",
-            column_values=dict(
-                title=_("Storage Expiry Date"),
-                toggle=True,
-            ),
-            after="getDateStored",
-            review_states=("stored", )
-        )
+    def is_lab_user(self):
+        """Returns whether the current user is not from a client
+        """
+        if api.get_current_client():
+            return False
+        return True
 
     def folder_item(self, obj, item, index):
         # Return immediately when add-on is not installed
@@ -162,4 +235,5 @@ class AnalysisRequestsListingViewAdapter(object):
         review_state = self.listing.review_state
         if not review_state:
             return False
-        return review_state.get("id", "") == "stored"
+        statuses = [st["id"] for st in ADD_REVIEW_STATES]
+        return review_state.get("id", "") in statuses

--- a/src/senaite/storage/adapters/listing.py
+++ b/src/senaite/storage/adapters/listing.py
@@ -59,7 +59,7 @@ ADD_COLUMNS = (
         "id": "getStorageExpiryDate",
         "title": _(
             u"listing_samples_column_storage_expiry_date",
-            default=u"Storage expiry date"
+            default=u"Retain Until"
         ),
         "index": "getStorageExpiryDate",
         "toggle": True,

--- a/src/senaite/storage/adapters/listing.py
+++ b/src/senaite/storage/adapters/listing.py
@@ -28,6 +28,7 @@ from senaite.app.listing.interfaces import IListingViewAdapter
 from senaite.core.api import dtime
 from senaite.storage import is_installed
 from senaite.storage import senaiteMessageFactory as _
+from senaite.storage import api as sapi
 from zope.component import adapter
 from zope.interface import implementer
 
@@ -130,11 +131,24 @@ class AnalysisRequestsListingViewAdapter(object):
     # Order of priority of this subscriber adapter over others
     priority_order = 10
 
+    # number of days before a sample's retention period ends when it should be
+    # marked as approaching expiration
+    _warning_days = None
+
     def __init__(self, listing, context):
         self.listing = listing
         self.context = context
         self.installed = is_installed()
         self.flat_listing = False
+
+    @property
+    def warning_days_before_expiration(self):
+        """Returns the number of days before a sample's retention period ends
+        when it should be marked as approaching expiration
+        """
+        if self._warning_days is None:
+            self._warning_days = sapi.get_warning_days_before_expiration()
+        return self._warning_days
 
     def before_render(self):
         # Return immediately if not installed
@@ -230,14 +244,18 @@ class AnalysisRequestsListingViewAdapter(object):
 
         # date when the retention period expires
         obj = api.get_object(obj)
+        column = "getStorageExpiryDate"
         expiry_date = obj.getStorageExpiryDate()
-        item["getStorageExpiryDate"] = dtime.to_localized_time(expiry_date)
+        expiry_str = dtime.to_localized_time(expiry_date)
+        item[column] = expiry_str
 
-        # display in red if retention expired
-        if expiry_date <= dtime.DateTime():
-            expiry = dtime.to_localized_time(expiry_date)
-            span = "<span class='text-danger'>%s</span>" % expiry
-            item["replace"]["getStorageExpiryDate"] = span
+        # visual indicators if retention expired or approaching expiration
+        warn_days = self.warning_days_before_expiration
+        span = "<span class='font-weight-bold %s'>%s</span>"
+        if sapi.is_retention_expired(obj):
+            item["replace"][column] = span % ("text-danger", expiry_str)
+        elif sapi.is_retention_approaching_expiration(obj, warn_days):
+            item["replace"][column] = span % ("text-warning", expiry_str)
 
         return item
 

--- a/src/senaite/storage/adapters/listing.py
+++ b/src/senaite/storage/adapters/listing.py
@@ -61,6 +61,7 @@ ADD_COLUMNS = (
             u"listing_samples_column_storage_expiry_date",
             default=u"Storage expiry date"
         ),
+        "index": "getStorageExpiryDate",
         "toggle": True,
         "after": "getDateStored",
         "review_states": ("stored", "past_retention"),
@@ -112,7 +113,7 @@ ADD_REVIEW_STATES = (
         ),
         "contentFilter": {
             "review_state": ("stored",),
-            "sort_on": "getDateStored",
+            "sort_on": "getStorageExpiryDate",
             "sort_order": "descending",
         },
         "transitions": [],
@@ -153,6 +154,17 @@ class AnalysisRequestsListingViewAdapter(object):
         if self.is_stored_state():
             self.flat_listing = True
             self.listing.contentFilter.pop("isRootAncestor", None)
+
+        # Update the contentFilter of the "past_retention" filter, so only
+        # stored samples whose retention period has passed are displayed
+        for rv in self.listing.review_states:
+            if rv.get("id") == "past_retention":
+                rv["contentFilter"].update({
+                    "getStorageExpiryDate": {
+                        "query": dtime.DateTime(),
+                        "range": "max",
+                    }
+                })
 
     def add_review_state(self, state_info):
         """Adds the review state with the provided information

--- a/src/senaite/storage/api.py
+++ b/src/senaite/storage/api.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 from bika.lims import api
+from senaite.core.api import dtime
 from senaite.storage import logger
 from senaite.storage.catalog import STORAGE_CATALOG
 from senaite.storage.config import PRODUCT_NAME
@@ -140,3 +141,34 @@ def get_parents(obj, parents=None, predicate=None):
     if predicate(parent):
         return parents
     return get_parents(parent, parents=parents, predicate=predicate)
+
+
+def get_warning_days_before_expiration():
+    """Returns the number of days before a sample's retention period ends
+    when it should be marked as approaching expiration
+    """
+    key = "{}.warning_days_before_expiration".format(PRODUCT_NAME)
+    days =  api.get_registry_record(key)
+    return api.to_int(days, default=5)
+
+
+def is_retention_expired(sample, on_date=None):
+    """Returns whether the storage retention period of this sample is expired
+    on the given date. If the on_date is None, uses current date
+    """
+    expiry_date = sample.getStorageExpiryDate()
+    if not expiry_date:
+        return None
+    if not on_date:
+        on_date = dtime.DateTime()
+    return expiry_date <= on_date
+
+
+def is_retention_approaching_expiration(sample, days=None):
+    """Returns whether the storage retention period of this sample is
+    approaching expiration
+    """
+    if days is None:
+        days = get_warning_days_before_expiration()
+    on_date = dtime.DateTime() + days
+    return is_retention_expired(sample, on_date)

--- a/src/senaite/storage/browser/container/samples.py
+++ b/src/senaite/storage/browser/container/samples.py
@@ -22,10 +22,12 @@ import collections
 
 from bika.lims import api
 from bika.lims import senaiteMessageFactory as _s
+from plone.memoize.view import memoize
 from senaite.app.listing.view import ListingView
 from senaite.core.api import dtime
 from senaite.core.catalog import SAMPLE_CATALOG
 from senaite.storage import senaiteMessageFactory as _
+from senaite.storage import api as sapi
 from senaite.storage.permissions import TransitionAddSamples
 
 
@@ -76,8 +78,19 @@ class SampleListingView(ListingView):
             ("getDateReceived", {
                 "title": _s("Date Received"),
                 "toggle": True}),
+            ("getDateSored", {
+                "title": _(
+                    u"listing_samples_column_date_stored",
+                    default=u"Date stored"
+                ),
+                "index": "getDateStored",
+                "toggle": True}),
             ("getStorageExpiryDate", {
-                "title": _("Storage Expiry Date"),
+                "title": _(
+                    u"listing_samples_column_storage_expiry_date",
+                    default=u"Retain Until"
+                ),
+                "index": "getStorageExpiryDate",
                 "toggle": True}),
             ("Client", {
                 "title": _s("Client"),
@@ -133,6 +146,13 @@ class SampleListingView(ListingView):
         """
         return self.context.plone_utils.addPortalMessage(message, level)
 
+    @memoize
+    def get_warning_days_before_expiration(self):
+        """Returns the number of days before a sample's retention period ends
+        when it should be marked as approaching expiration
+        """
+        return sapi.get_warning_days_before_expiration()
+
     def folderitems(self):
         """We add this function to tell baselisting to use brains instead of
         full objects"""
@@ -156,15 +176,18 @@ class SampleListingView(ListingView):
             item["PreviousState"] = self.translate_review_state(
                 prev_state, api.get_portal_type(obj))
 
-        # storage expiry date
+        # date when the retention period expires
         column = "getStorageExpiryDate"
         expiry_date = obj.getStorageExpiryDate()
-        item[column] = self.ulocalized_time(expiry_date)
+        expiry_str = dtime.to_localized_time(expiry_date)
+        item[column] = expiry_str
 
-        # display in red if retention expired
-        if expiry_date <= dtime.DateTime():
-            expiry = self.ulocalized_time(expiry_date)
-            span = "<span class='text-danger'>%s</span>" % expiry
-            item["replace"][column] = span
+        # visual indicators if retention expired or approaching expiration
+        warn_days = self.get_warning_days_before_expiration()
+        span = "<span class='font-weight-bold %s'>%s</span>"
+        if sapi.is_retention_expired(obj):
+            item["replace"][column] = span % ("text-danger", expiry_str)
+        elif sapi.is_retention_approaching_expiration(obj, warn_days):
+            item["replace"][column] = span % ("text-warning", expiry_str)
 
         return item

--- a/src/senaite/storage/browser/container/store_container.py
+++ b/src/senaite/storage/browser/container/store_container.py
@@ -23,11 +23,13 @@ import json
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _s
 from DateTime import DateTime
+from plone.memoize.view import memoize
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from senaite.core.catalog import SAMPLE_CATALOG
 from senaite.core.workflow import SAMPLE_WORKFLOW
 from senaite.storage import logger
 from senaite.storage import senaiteMessageFactory as _
+from senaite.storage import api as sapi
 from senaite.storage.browser import BaseView
 from senaite.storage.interfaces import IStorageSamplesContainer
 
@@ -121,6 +123,13 @@ class StoreContainerView(BaseView):
         }
         return json.dumps(base_query)
 
+    @memoize
+    def get_warning_days_before_expiration(self):
+        """Returns the number of days before a sample's retention period ends
+        when it should be marked as approaching expiration
+        """
+        return sapi.get_warning_days_before_expiration()
+
     def get_sample_info(self, sample):
         """Returns the sample info
         """
@@ -134,6 +143,15 @@ class StoreContainerView(BaseView):
         state = sample_wf.states.get(status)
         if state:
             status_title = state.title
+
+        # display in orange or red depending on the retention period
+        css = ["non-empty-slot"]
+        warn_days = self.get_warning_days_before_expiration()
+        if sapi.is_retention_expired(sample):
+            css.append("bg-danger")
+        elif sapi.is_retention_approaching_expiration(sample, warn_days):
+            css.append("bg-warning")
+
         return {
             "obj": sample,
             "id": api.get_id(sample),
@@ -143,6 +161,7 @@ class StoreContainerView(BaseView):
             "sample_type": sample.getSampleTypeTitle(),
             "status": status,
             "status_title": status_title,
+            "css": " ".join(css),
         }
 
     def get_allowed_states(self):

--- a/src/senaite/storage/browser/container/templates/store_container.pt
+++ b/src/senaite/storage/browser/container/templates/store_container.pt
@@ -151,7 +151,7 @@
                         </div>
                       </td>
                       <td tal:condition="python: item and True or False"
-                          class="non-empty-slot">
+                          tal:attributes="class python: info.get('css','non-empty-slot')">
                         <!-- sample title -->
                         <a href="#"
                            tal:attributes="href info/url">

--- a/src/senaite/storage/browser/controlpanel.py
+++ b/src/senaite/storage/browser/controlpanel.py
@@ -123,6 +123,21 @@ class IStorageControlPanel(model.Schema):
         default=True,
     )
 
+    warning_days_before_expiration = schema.Int(
+        title=_(
+            u"label_storage_settings_warning_days_expiration",
+            default=u"Days before expiration"
+        ),
+        description=_(
+            u"description_storage_settings_warning_days_expiration",
+            default=u"Enter the number of days before a sample's retention "
+                    u"period ends when it should be marked as approaching "
+                    u"expiration. Samples within this threshold will display "
+                    u"a visual indicator to help you quickly identify them."
+        ),
+        default=5,
+    )
+
     directives.widget(
         "retention_period_rules",
         DataGridWidgetFactory,

--- a/src/senaite/storage/browser/controlpanel.py
+++ b/src/senaite/storage/browser/controlpanel.py
@@ -91,6 +91,7 @@ class IStorageControlPanel(model.Schema):
         label=_(u"Retention Rules"),
         description=_(u""),
         fields=[
+            "warning_days_before_expiration",
             "retention_period_rules",
         ],
     )

--- a/src/senaite/storage/profiles/default/metadata.xml
+++ b/src/senaite/storage/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>2708</version>
+  <version>2709</version>
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>
     <dependency>profile-senaite.lims:default</dependency>

--- a/src/senaite/storage/profiles/default/metadata.xml
+++ b/src/senaite/storage/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>2707</version>
+  <version>2708</version>
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>
     <dependency>profile-senaite.lims:default</dependency>

--- a/src/senaite/storage/setuphandlers.py
+++ b/src/senaite/storage/setuphandlers.py
@@ -86,6 +86,7 @@ CATALOG_MAPPINGS = [
 INDEXES = [
     # Index used in ARs view to sort items by date stored by default
     (SAMPLE_CATALOG, "getDateStored", "", "DateIndex"),
+    (SAMPLE_CATALOG, "getStorageExpiryDate", "", "DateIndex"),
 ]
 
 # Tuples of (catalog, column name)

--- a/src/senaite/storage/tests/doctests/RetentionPeriod.rst
+++ b/src/senaite/storage/tests/doctests/RetentionPeriod.rst
@@ -407,3 +407,122 @@ Recover again and verify cleanup:
     (...)
     >>> sample1.getStorageExpiryDate() is None
     True
+
+
+Warning days before expiration
+..............................
+
+The control panel setting ``warning_days_before_expiration`` controls how many
+days before the expiry date a sample should be flagged as approaching
+expiration. The default value is 5:
+
+    >>> storage_api.get_warning_days_before_expiration()
+    5
+
+The value can be changed through the registry:
+
+    >>> def set_warning_days(days):
+    ...     key = "senaite.storage.warning_days_before_expiration"
+    ...     ploneapi.portal.set_registry_record(key, days)
+
+    >>> set_warning_days(10)
+    >>> storage_api.get_warning_days_before_expiration()
+    10
+
+Reset to default for subsequent tests:
+
+    >>> set_warning_days(5)
+
+
+Retention expiration check
+..........................
+
+The ``is_retention_expired`` function checks whether a sample's retention
+period has expired. It returns ``None`` if the sample has no expiry date:
+
+    >>> sample1.getStorageExpiryDate() is None
+    True
+    >>> storage_api.is_retention_expired(sample1) is None
+    True
+
+Store the sample and set an expiry date 30 days from now:
+
+    >>> set_retention_rules([
+    ...     {"service": Cu_uid, "result": u"", "retention_days": 30},
+    ... ])
+    >>> ssc.add_object_at(sample1, 0, 0)
+    True
+    >>> expiry = DateTime() + 30
+    >>> sample1.setStorageExpiryDate(expiry)
+
+The retention is not expired (expiry is 30 days from now):
+
+    >>> storage_api.is_retention_expired(sample1)
+    False
+
+Check against a specific date in the future (31 days from now):
+
+    >>> future_date = DateTime() + 31
+    >>> storage_api.is_retention_expired(sample1, on_date=future_date)
+    True
+
+Check against a specific date before the expiry (29 days from now):
+
+    >>> before_date = DateTime() + 29
+    >>> storage_api.is_retention_expired(sample1, on_date=before_date)
+    False
+
+Set the expiry date in the past to simulate an expired retention:
+
+    >>> sample1.setStorageExpiryDate(DateTime() - 1)
+    >>> storage_api.is_retention_expired(sample1)
+    True
+
+
+Approaching expiration check
+.............................
+
+The ``is_retention_approaching_expiration`` function checks whether a sample's
+retention period is approaching expiration within the given number of days.
+
+Set the expiry date to 3 days from now:
+
+    >>> sample1.setStorageExpiryDate(DateTime() + 3)
+
+With the default warning threshold of 5 days, the sample is approaching
+expiration (3 days < 5 days threshold):
+
+    >>> storage_api.is_retention_approaching_expiration(sample1)
+    True
+
+With a custom threshold of 2 days, the sample is NOT approaching expiration
+(3 days > 2 days threshold):
+
+    >>> storage_api.is_retention_approaching_expiration(sample1, days=2)
+    False
+
+A sample with an expiry date far in the future is not approaching expiration:
+
+    >>> sample1.setStorageExpiryDate(DateTime() + 30)
+    >>> storage_api.is_retention_approaching_expiration(sample1)
+    False
+
+An already expired sample is also considered as approaching expiration (since
+``is_retention_approaching_expiration`` delegates to ``is_retention_expired``
+with a future date offset):
+
+    >>> sample1.setStorageExpiryDate(DateTime() - 1)
+    >>> storage_api.is_retention_approaching_expiration(sample1)
+    True
+
+A sample without an expiry date returns None:
+
+    >>> sample1.setStorageExpiryDate(None)
+    >>> storage_api.is_retention_approaching_expiration(sample1) is None
+    True
+
+Cleanup:
+
+    >>> do_action_for(sample1, "recover")
+    (...)
+    >>> set_retention_rules([])

--- a/src/senaite/storage/upgrade/v02_07_000.py
+++ b/src/senaite/storage/upgrade/v02_07_000.py
@@ -557,3 +557,15 @@ def setup_past_retention_filter(tool):
         obj._p_deactivate()
 
     logger.info("Setup past retention filter [DONE]")
+
+
+def setup_days_before_expiration(tool):
+    """Add 'Days before expiration' setting in control panel
+    """
+    logger.info("Setup days before expiration ...")
+
+    portal = tool.aq_inner.aq_parent
+    setup = portal.portal_setup  # noqa
+    setup.runImportStepFromProfile(profile, "plone.app.registry")
+
+    logger.info("Setup days before expiration [DONE]")

--- a/src/senaite/storage/upgrade/v02_07_000.py
+++ b/src/senaite/storage/upgrade/v02_07_000.py
@@ -25,6 +25,7 @@ from plone.dexterity.utils import createContent
 from senaite.core.api import workflow as wapi
 from senaite.core.interfaces import IContentMigrator
 from senaite.core.schema.addressfield import PHYSICAL_ADDRESS
+from senaite.core.setuphandlers import add_catalog_index
 from senaite.core.upgrade import upgradestep
 from senaite.core.upgrade.utils import UpgradeUtils
 from senaite.core.workflow import SAMPLE_WORKFLOW
@@ -529,3 +530,29 @@ def setup_retention_period_rules(tool):
     setup.runImportStepFromProfile(profile, "plone.app.registry")
 
     logger.info("Setup retention period rules [DONE]")
+
+
+def setup_past_retention_filter(tool):
+    """Adds a DateIndex in samples catalog ('getStorageExpiryDate') to allow
+    date range searches by retention period expiry date
+    """
+    logger.info("Setup past retention filter ...")
+    portal = tool.aq_inner.aq_parent
+
+    # Add the index (without reindex)
+    cat = api.get_tool(SAMPLE_CATALOG)
+    idx_id = "getStorageExpiryDate"
+    add_catalog_index(cat, idx_id, "", "DateIndex")
+
+    # reindex this index only for samples in stored status
+    brains = cat(review_state="stored")
+    total = len(brains)
+    for num, brain in enumerate(brains):
+        if num and num % 100 == 0:
+            logger.info("Processed objects: {0}/{1}".format(num, total))
+
+        obj = api.get_object(brain)
+        obj.reindexObject(idxs=[idx_id])
+        obj._p_deactivate()
+
+    logger.info("Setup past retention filter [DONE]")

--- a/src/senaite/storage/upgrade/v02_07_000.py
+++ b/src/senaite/storage/upgrade/v02_07_000.py
@@ -550,6 +550,7 @@ def setup_past_retention_filter(tool):
     for num, brain in enumerate(brains):
         if num and num % 100 == 0:
             logger.info("Processed objects: {0}/{1}".format(num, total))
+            transaction.savepoint()
 
         obj = api.get_object(brain)
         obj.reindexObject(idxs=[idx_id])

--- a/src/senaite/storage/upgrade/v02_07_000.zcml
+++ b/src/senaite/storage/upgrade/v02_07_000.zcml
@@ -3,6 +3,18 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="Add 'Days before expiration' setting"
+      description="
+        This setting stores the number of days before a sample's retention
+        period ends when it should be marked as approaching expiration.
+        Samples within this threshold will display a visual indicator to help
+        lab personnel to quickly identify them."
+      source="2708"
+      destination="2709"
+      handler=".v02_07_000.setup_days_before_expiration"
+      profile="senaite.storage:default"/>
+
+  <genericsetup:upgradeStep
       title="Add 'Past Retention' filter in samples listing"
       description="
         Adds a 'Past Retention' filter in samples listing and a DateIndex in

--- a/src/senaite/storage/upgrade/v02_07_000.zcml
+++ b/src/senaite/storage/upgrade/v02_07_000.zcml
@@ -3,6 +3,17 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="Add 'Past Retention' filter in samples listing"
+      description="
+        Adds a 'Past Retention' filter in samples listing and a DateIndex in
+        samples catalog ('getStorageExpiryDate') to allow date range searches
+        by retention period expiry date."
+      source="2707"
+      destination="2708"
+      handler=".v02_07_000.setup_past_retention_filter"
+      profile="senaite.storage:default"/>
+
+  <genericsetup:upgradeStep
       title="Setup retention period rules"
       description="
         Register retention period rules field in the registry for


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

> [!IMPORTANT]
> **Merge the following PR first!**:
> - #65

This Pull Request adds a configurable "Days before expiration" setting in the Storage control panel that defines the threshold for flagging samples approaching their retention expiry date (default: 5 days) and applies colors to allow users to quickly distinguish expired samples, samples approaching expiration and samples not expired.

General samples listing:

<img width="1844" height="493" alt="20260308062720" src="https://github.com/user-attachments/assets/8f305c7d-e957-40ed-9f07-c09b9eefb9a6" />

Samples listing inside a samples container:

<img width="1844" height="546" alt="20260308062713" src="https://github.com/user-attachments/assets/80e987e1-030f-4cea-ae4e-1eeab8529de9" />

Layout view inside a samples container:

<img width="1841" height="727" alt="20260308062728" src="https://github.com/user-attachments/assets/17676b2d-7e47-4c55-8dec-3ca4e33cbfe7" />

## Current behavior before PR

Only visual indicator for samples whose retention period has expired

## Desired behavior after PR is merged

Visual indicator for samples whose retention period has expired and those approaching expiration

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
