### PR TITLE
Rename "Recover" transtion to "Retrieve" to align with ISO 17025/15189

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #67 Rename "Recover" transtion to "Retrieve" to align with ISO 17025/15189
 - #66 Add visual warning for samples approaching retention expiration
 - #65 Add a "Past Retention" filter in samples listing
 - #63 Result type-specific controls in retention rules settings

--- a/src/senaite/storage/browser/controlpanel.py
+++ b/src/senaite/storage/browser/controlpanel.py
@@ -113,13 +113,13 @@ class IStorageControlPanel(model.Schema):
     recover_primary = schema.Bool(
         title=_(
             u"label_storage_settings_recover_primary",
-            default=u"Auto-recover primary sample"
+            default=u"Auto-retrieve primary sample"
         ),
         description=_(
             u"description_storage_settings_recover_primary",
             default=u"Select this option to automatically transition back the "
                     u"primary from 'stored' to its preceding status when all "
-                    u"its partitions are recovered."
+                    u"its partitions are retrieved."
         ),
         default=True,
     )

--- a/src/senaite/storage/locales/cs/LC_MESSAGES/senaite.storage.po
+++ b/src/senaite/storage/locales/cs/LC_MESSAGES/senaite.storage.po
@@ -254,7 +254,7 @@ msgid "Print stickers"
 msgstr "Tisk samolepek"
 
 #: senaite/storage/profiles/default/workflows/senaite_storage_default_workflow/definition.xml
-msgid "Recover samples"
+msgid "Retrieve samples"
 msgstr "Obnovit vzorky"
 
 #: senaite/storage/content/storagelayoutcontainer.py:48
@@ -360,7 +360,7 @@ msgstr "Skladovací pozice uvnitř zařízení"
 msgid "Used positions:"
 msgstr "Použité pozice:"
 
-#. Default: "Select this option to automatically transition back the primary from 'stored' to its preceding status when all its partitions are recovered."
+#. Default: "Select this option to automatically transition back the primary from 'stored' to its preceding status when all its partitions are retrieved."
 #: senaite/storage/browser/controlpanel.py:52
 msgid "description_storage_settings_recover_primary"
 msgstr ""
@@ -375,7 +375,7 @@ msgstr ""
 msgid "header_storage_settings"
 msgstr ""
 
-#. Default: "Auto-recover primary sample"
+#. Default: "Auto-retrieve primary sample"
 #: senaite/storage/browser/controlpanel.py:48
 msgid "label_storage_settings_recover_primary"
 msgstr ""

--- a/src/senaite/storage/locales/de/LC_MESSAGES/senaite.storage.po
+++ b/src/senaite/storage/locales/de/LC_MESSAGES/senaite.storage.po
@@ -255,7 +255,7 @@ msgid "Print stickers"
 msgstr "Aufkleber drucken"
 
 #: senaite/storage/profiles/default/workflows/senaite_storage_default_workflow/definition.xml
-msgid "Recover samples"
+msgid "Retrieve samples"
 msgstr "Probe wieder herstellen"
 
 #: senaite/storage/content/storagelayoutcontainer.py:48
@@ -361,7 +361,7 @@ msgstr "Der Lagerraum innerhalb eines Lagerorts"
 msgid "Used positions:"
 msgstr "Benutzte Halterungen:"
 
-#. Default: "Select this option to automatically transition back the primary from 'stored' to its preceding status when all its partitions are recovered."
+#. Default: "Select this option to automatically transition back the primary from 'stored' to its preceding status when all its partitions are retrieved."
 #: senaite/storage/browser/controlpanel.py:52
 msgid "description_storage_settings_recover_primary"
 msgstr ""
@@ -376,7 +376,7 @@ msgstr ""
 msgid "header_storage_settings"
 msgstr ""
 
-#. Default: "Auto-recover primary sample"
+#. Default: "Auto-retrieve primary sample"
 #: senaite/storage/browser/controlpanel.py:48
 msgid "label_storage_settings_recover_primary"
 msgstr ""

--- a/src/senaite/storage/locales/en/LC_MESSAGES/senaite.storage.po
+++ b/src/senaite/storage/locales/en/LC_MESSAGES/senaite.storage.po
@@ -247,7 +247,7 @@ msgid "Print stickers"
 msgstr ""
 
 #: senaite/storage/profiles/default/workflows/senaite_storage_default_workflow/definition.xml
-msgid "Recover samples"
+msgid "Retrieve samples"
 msgstr ""
 
 #: senaite/storage/content/storagelayoutcontainer.py:48
@@ -353,7 +353,7 @@ msgstr ""
 msgid "Used positions:"
 msgstr ""
 
-#. Default: "Select this option to automatically transition back the primary from 'stored' to its preceding status when all its partitions are recovered."
+#. Default: "Select this option to automatically transition back the primary from 'stored' to its preceding status when all its partitions are retrieved."
 #: senaite/storage/browser/controlpanel.py:52
 msgid "description_storage_settings_recover_primary"
 msgstr ""
@@ -368,7 +368,7 @@ msgstr ""
 msgid "header_storage_settings"
 msgstr ""
 
-#. Default: "Auto-recover primary sample"
+#. Default: "Auto-retrieve primary sample"
 #: senaite/storage/browser/controlpanel.py:48
 msgid "label_storage_settings_recover_primary"
 msgstr ""

--- a/src/senaite/storage/locales/es/LC_MESSAGES/senaite.storage.po
+++ b/src/senaite/storage/locales/es/LC_MESSAGES/senaite.storage.po
@@ -255,7 +255,7 @@ msgid "Print stickers"
 msgstr "Imprimir etiquetas"
 
 #: senaite/storage/profiles/default/workflows/senaite_storage_default_workflow/definition.xml
-msgid "Recover samples"
+msgid "Retrieve samples"
 msgstr "Recuperar muestras"
 
 #: senaite/storage/content/storagelayoutcontainer.py:48
@@ -361,7 +361,7 @@ msgstr "La posición de almacenamiento dentro de la instalación"
 msgid "Used positions:"
 msgstr "Posiciones utilizadas:"
 
-#. Default: "Select this option to automatically transition back the primary from 'stored' to its preceding status when all its partitions are recovered."
+#. Default: "Select this option to automatically transition back the primary from 'stored' to its preceding status when all its partitions are retrieved."
 #: senaite/storage/browser/controlpanel.py:52
 msgid "description_storage_settings_recover_primary"
 msgstr ""
@@ -376,7 +376,7 @@ msgstr ""
 msgid "header_storage_settings"
 msgstr ""
 
-#. Default: "Auto-recover primary sample"
+#. Default: "Auto-retrieve primary sample"
 #: senaite/storage/browser/controlpanel.py:48
 msgid "label_storage_settings_recover_primary"
 msgstr ""

--- a/src/senaite/storage/locales/pt_BR/LC_MESSAGES/senaite.storage.po
+++ b/src/senaite/storage/locales/pt_BR/LC_MESSAGES/senaite.storage.po
@@ -251,7 +251,7 @@ msgid "Print stickers"
 msgstr ""
 
 #: senaite/storage/profiles/default/workflows/senaite_storage_default_workflow/definition.xml
-msgid "Recover samples"
+msgid "Retrieve samples"
 msgstr ""
 
 #: senaite/storage/content/storagelayoutcontainer.py:48
@@ -357,7 +357,7 @@ msgstr ""
 msgid "Used positions:"
 msgstr ""
 
-#. Default: "Select this option to automatically transition back the primary from 'stored' to its preceding status when all its partitions are recovered."
+#. Default: "Select this option to automatically transition back the primary from 'stored' to its preceding status when all its partitions are retrieved."
 #: senaite/storage/browser/controlpanel.py:52
 msgid "description_storage_settings_recover_primary"
 msgstr ""
@@ -372,7 +372,7 @@ msgstr ""
 msgid "header_storage_settings"
 msgstr ""
 
-#. Default: "Auto-recover primary sample"
+#. Default: "Auto-retrieve primary sample"
 #: senaite/storage/browser/controlpanel.py:48
 msgid "label_storage_settings_recover_primary"
 msgstr ""

--- a/src/senaite/storage/locales/zh/LC_MESSAGES/senaite.storage.po
+++ b/src/senaite/storage/locales/zh/LC_MESSAGES/senaite.storage.po
@@ -255,7 +255,7 @@ msgid "Print stickers"
 msgstr "打印标签"
 
 #: senaite/storage/profiles/default/workflows/senaite_storage_default_workflow/definition.xml
-msgid "Recover samples"
+msgid "Retrieve samples"
 msgstr "取出样本"
 
 #: senaite/storage/content/storagelayoutcontainer.py:48
@@ -361,7 +361,7 @@ msgstr "设施中的存储位置"
 msgid "Used positions:"
 msgstr "已使用位置："
 
-#. Default: "Select this option to automatically transition back the primary from 'stored' to its preceding status when all its partitions are recovered."
+#. Default: "Select this option to automatically transition back the primary from 'stored' to its preceding status when all its partitions are retrieved."
 #: senaite/storage/browser/controlpanel.py:52
 msgid "description_storage_settings_recover_primary"
 msgstr ""
@@ -376,7 +376,7 @@ msgstr ""
 msgid "header_storage_settings"
 msgstr ""
 
-#. Default: "Auto-recover primary sample"
+#. Default: "Auto-retrieve primary sample"
 #: senaite/storage/browser/controlpanel.py:48
 msgid "label_storage_settings_recover_primary"
 msgstr ""

--- a/src/senaite/storage/locales/zh_CN/LC_MESSAGES/senaite.storage.po
+++ b/src/senaite/storage/locales/zh_CN/LC_MESSAGES/senaite.storage.po
@@ -251,7 +251,7 @@ msgid "Print stickers"
 msgstr ""
 
 #: senaite/storage/profiles/default/workflows/senaite_storage_default_workflow/definition.xml
-msgid "Recover samples"
+msgid "Retrieve samples"
 msgstr ""
 
 #: senaite/storage/content/storagelayoutcontainer.py:48
@@ -357,7 +357,7 @@ msgstr ""
 msgid "Used positions:"
 msgstr ""
 
-#. Default: "Select this option to automatically transition back the primary from 'stored' to its preceding status when all its partitions are recovered."
+#. Default: "Select this option to automatically transition back the primary from 'stored' to its preceding status when all its partitions are retrieved."
 #: senaite/storage/browser/controlpanel.py:52
 msgid "description_storage_settings_recover_primary"
 msgstr ""
@@ -372,7 +372,7 @@ msgstr ""
 msgid "header_storage_settings"
 msgstr ""
 
-#. Default: "Auto-recover primary sample"
+#. Default: "Auto-retrieve primary sample"
 #: senaite/storage/browser/controlpanel.py:48
 msgid "label_storage_settings_recover_primary"
 msgstr ""

--- a/src/senaite/storage/profiles/default/metadata.xml
+++ b/src/senaite/storage/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>2709</version>
+  <version>2710</version>
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>
     <dependency>profile-senaite.lims:default</dependency>

--- a/src/senaite/storage/profiles/default/rolemap.xml
+++ b/src/senaite/storage/profiles/default/rolemap.xml
@@ -46,7 +46,7 @@
       <role name="StorageAssistant"/>
     </permission>
 
-    <!-- Store/Recover Sample Transition Permissions (sample objects) -->
+    <!-- Store/Retrieve Sample Transition Permissions (sample objects) -->
     <permission name="senaite.storage: Transition: Store Sample" acquire="False">
       <role name="LabClerk"/>
       <role name="LabManager"/>
@@ -62,7 +62,7 @@
       <role name="StorageAssistant"/>
     </permission>
 
-    <!-- Add/Recover Samples Transition Permissions (storage listings) -->
+    <!-- Add/Retrieve Samples Transition Permissions (storage listings) -->
     <permission name="senaite.storage: Transition: Add Samples" acquire="False">
       <role name="LabClerk"/>
       <role name="LabManager"/>

--- a/src/senaite/storage/profiles/default/workflows/senaite_storage_default_workflow/definition.xml
+++ b/src/senaite/storage/profiles/default/workflows/senaite_storage_default_workflow/definition.xml
@@ -119,11 +119,15 @@
     </guard>
   </transition>
 
-  <!-- Transition: recover_samples -->
-  <transition transition_id="recover_samples" title="Recover samples"
+  <!-- Transition: recover_samples
+       NOTE: The transition ID "recover_samples" is kept for historical
+       reasons. The user-facing term is "retrieve", which aligns with
+       ISO 17025 and ISO 15189 standard terminology for the process of
+       taking samples out of storage. -->
+  <transition transition_id="recover_samples" title="Retrieve samples"
               new_state="" trigger="USER" before_script="" after_script=""
               i18n:attributes="title">
-    <action url="" category="workflow" icon="">Recover samples</action>
+    <action url="" category="workflow" icon="">Retrieve samples</action>
     <guard>
       <guard-permission>senaite.storage: Transition: Recover Samples</guard-permission>
       <guard-expression>python:here.guard_handler("recover_samples")</guard-expression>

--- a/src/senaite/storage/setuphandlers.py
+++ b/src/senaite/storage/setuphandlers.py
@@ -161,12 +161,16 @@ WORKFLOWS_TO_UPDATE = {
                     "guard_expr": "python:here.guard_handler('store')",
                 }
             },
+            # NOTE: The transition ID "recover" is kept for historical
+            # reasons. The user-facing term is "retrieve", which aligns
+            # with ISO 17025 and ISO 15189 standard terminology for
+            # the process of taking samples out of storage.
             "recover": {
-                "title": "Recover",
+                "title": "Retrieve",
                 # We set same new_state here because system will transition the
                 # sample to the state before when was stored. See events
                 "new_state": "stored",
-                "action": "Recover sample",
+                "action": "Retrieve sample",
                 "guard": {
                     "guard_permissions": "senaite.storage: Transition: Recover Sample",  # noqa
                     "guard_roles": "",
@@ -267,7 +271,7 @@ def post_install(portal_setup):
     # Setup ID Formatting for Storage content types
     setup_id_formatting(portal)
 
-    # Injects "store" and "recover" transitions into senaite's workflow
+    # Injects "store" and "retrieve" transitions into senaite's workflow
     setup_workflows(portal)
 
     # reindex storage structure
@@ -289,8 +293,8 @@ def post_uninstall(portal_setup):
     context = portal_setup._getImportContext(profile_id)  # noqa
     portal = context.getSite()  # noqa
 
-    # recover all stored samples
-    recover_samples(portal)
+    # retrieve all stored samples
+    retrieve_samples(portal)
 
     # unindex the storage structure
     # -> makes it disappear in the navigation
@@ -378,7 +382,7 @@ def setup_user_groups(portal):
 
 
 def setup_workflows(portal):
-    """Injects 'store' and 'recover' transitions into workflow
+    """Injects 'store' and 'retrieve' transitions into workflow
     """
     logger.info("Setup storage workflow ...")
     for wf_id, settings in WORKFLOWS_TO_UPDATE.items():
@@ -518,19 +522,19 @@ def unindex_storage_structure(portal):
     storage.unindexObject()
 
 
-def recover_samples(portal):
-    """recover all stored samples
+def retrieve_samples(portal):
+    """Retrieve all stored samples
     """
-    logger.info("*** Recovering all stored samples ***")
+    logger.info("*** Retrieving all stored samples ***")
     catalog = api.get_tool(SAMPLE_CATALOG)
     query = {"review_state": "stored"}
     brains = catalog(query)
     total = len(brains)
-    logger.info("Recovering {} samples ... ".format(total))
+    logger.info("Retrieving {} samples ... ".format(total))
     for num, brain in enumerate(brains):
         obj = api.get_object(brain)
         api.do_transition_for(obj, "recover")
-        logger.info("Recovering sample {}/{}: {}".format(
+        logger.info("Retrieving sample {}/{}: {}".format(
             num + 1, total, api.get_id(obj)))
 
 

--- a/src/senaite/storage/tests/doctests/PrimarySample.rst
+++ b/src/senaite/storage/tests/doctests/PrimarySample.rst
@@ -3,8 +3,9 @@ Primary Sample
 
 When using partitions, `senaite.storage` automatically transitions the primary
 samples for them to follow the status of their partitions. This applies for
-both `store` and `recover` transitions. Although this is the behavior set by
-default, user can change it from Storage's control panel, under Site setup.
+both `store` and `recover` (retrieve) transitions. Although this is the
+behavior set by default, user can change it from Storage's control panel,
+under Site setup.
 
 Test Setup
 ..........
@@ -109,7 +110,7 @@ The primary is automatically transitioned to `stored` status too:
     >>> api.get_review_status(sample)
     'stored'
 
-Restore the partition 1:
+Retrieve the partition 1:
 
     >>> transitioned = do_action_for(part1, "recover")
     >>> api.get_review_status(part1)
@@ -119,7 +120,7 @@ Restore the partition 1:
     >>> api.get_review_status(sample)
     'stored'
 
-Restore the partition 2:
+Retrieve the partition 2:
 
     >>> transitioned = do_action_for(part2, "recover")
     >>> api.get_review_status(part2)
@@ -221,7 +222,7 @@ We can manually store the primary though:
     >>> api.get_review_status(sample)
     'stored'
 
-If we recover the partitions:
+If we retrieve the partitions:
 
     >>> do_action_for(part1, "recover")
     (True, '')
@@ -233,7 +234,7 @@ The primary remains in `stored` status:
     >>> api.get_review_status(sample)
     'stored'
 
-We can manually recover the primary:
+We can manually retrieve the primary:
 
     >>> success = do_action_for(sample, "recover")
     >>> api.get_review_status(sample)

--- a/src/senaite/storage/tests/doctests/RetentionPeriod.rst
+++ b/src/senaite/storage/tests/doctests/RetentionPeriod.rst
@@ -356,10 +356,10 @@ A sample can be stored without an expiry date:
     True
 
 
-Recovery clears the expiry date
-................................
+Retrieval clears the expiry date
+.................................
 
-When a stored sample is recovered, the expiry date is cleared:
+When a stored sample is retrieved, the expiry date is cleared:
 
     >>> sample1.getStorageExpiryDate() is not None
     True
@@ -382,7 +382,7 @@ The sample is no longer in the container:
 Re-storing with updated rules
 ..............................
 
-Rules can be changed between store/recover cycles. Store the sample again
+Rules can be changed between store/retrieve cycles. Store the sample again
 with a different retention period:
 
     >>> set_retention_rules([
@@ -401,7 +401,7 @@ with a different retention period:
     >>> days_diff
     7
 
-Recover again and verify cleanup:
+Retrieve again and verify cleanup:
 
     >>> do_action_for(sample1, "recover")
     (...)

--- a/src/senaite/storage/tests/doctests/StorageAssistant.rst
+++ b/src/senaite/storage/tests/doctests/StorageAssistant.rst
@@ -309,15 +309,15 @@ StorageAssistant can store the sample:
     1
 
 
-StorageAssistant CAN recover samples
-....................................
+StorageAssistant CAN retrieve samples
+.....................................
 
-The `recover` transition is available for stored samples:
+The `recover` transition (retrieve) is available for stored samples:
 
     >>> "recover" in getAllowedTransitions(sample)
     True
 
-StorageAssistant can recover samples:
+StorageAssistant can retrieve samples:
 
     >>> transitioned = do_action_for(sample, "recover")
     >>> api.get_workflow_status_of(sample)
@@ -327,8 +327,8 @@ StorageAssistant can recover samples:
     0
 
 
-StorageAssistant CAN store and recover samples created by other users
-.....................................................................
+StorageAssistant CAN store and retrieve samples created by other users
+......................................................................
 
 Create a sample as LabClerk and store it:
 
@@ -342,7 +342,7 @@ Create a sample as LabClerk and store it:
     >>> api.get_workflow_status_of(sample2)
     'stored'
 
-Switch to StorageAssistant and recover the sample:
+Switch to StorageAssistant and retrieve the sample:
 
     >>> setRoles(portal, TEST_USER_ID, ["StorageAssistant"])
 

--- a/src/senaite/storage/tests/doctests/StorageManager.rst
+++ b/src/senaite/storage/tests/doctests/StorageManager.rst
@@ -360,10 +360,10 @@ Move the samples container to a different container:
     '/plone/senaite_storage/SF-00001/SP-00002/SC-00003/SS-00001'
 
 
-StorageManager can recover samples from samples containers
-..........................................................
+StorageManager can retrieve samples from samples containers
+...........................................................
 
-Users with `StorageManager` role can recover samples from storage, but they
+Users with `StorageManager` role can retrieve samples from storage, but they
 cannot create samples. Samples must be created by users with other roles such
 as `LabClerk`.
 
@@ -403,16 +403,16 @@ LabClerk stores the sample in the samples container:
     >>> samples_container.get_samples_utilization()
     1
 
-Now switch to `StorageManager` role to recover the sample:
+Now switch to `StorageManager` role to retrieve the sample:
 
     >>> setRoles(portal, TEST_USER_ID, ["StorageManager"])
 
-The `recover` transition is available for stored samples:
+The `recover` transition (retrieve) is available for stored samples:
 
     >>> "recover" in getAllowedTransitions(sample)
     True
 
-StorageManager can recover samples that were stored by other users:
+StorageManager can retrieve samples that were stored by other users:
 
     >>> transitioned = do_action_for(sample, "recover")
     >>> api.get_workflow_status_of(sample)

--- a/src/senaite/storage/tests/doctests/StoragePermissions.rst
+++ b/src/senaite/storage/tests/doctests/StoragePermissions.rst
@@ -260,10 +260,10 @@ And containers:
     False
 
 
-Add/Recover Samples transition permissions
-..........................................
+Add/Retrieve Samples transition permissions
+...........................................
 
-Both `StorageManager` and `StorageAssistant` can add and recover samples from
+Both `StorageManager` and `StorageAssistant` can add and retrieve samples from
 storage containers:
 
     >>> "StorageManager" in rolesForPermissionOn("senaite.storage: Transition: Add Samples", samples_container)

--- a/src/senaite/storage/tests/doctests/StorageWorkflow.rst
+++ b/src/senaite/storage/tests/doctests/StorageWorkflow.rst
@@ -207,7 +207,7 @@ Now the sample can be stored:
     1
 
 
-Recovering stored samples
+Retrieving stored samples
 .........................
 
 As soon as a samples container has stored samples, the `recover_samples`
@@ -216,7 +216,7 @@ transition is available:
    >>> getAllowedTransitions(ssc)
    ['deactivate', 'move_container', 'add_samples', 'recover_samples']
 
-Recovering a sample restores the previous workflow state of the sample:
+Retrieving a sample restores the previous workflow state of the sample:
 
     >>> transitioned = do_action_for(sample, "recover")
 
@@ -261,7 +261,7 @@ Stored samples can be dispatched:
     >>> api.get_workflow_status_of(sample)
     'dispatched'
 
-Dispatched samples will be automatically recovered from the storage first:
+Dispatched samples will be automatically retrieved from storage first:
 
     >>> ssc.has_samples()
     False

--- a/src/senaite/storage/upgrade/v02_07_000.py
+++ b/src/senaite/storage/upgrade/v02_07_000.py
@@ -569,3 +569,22 @@ def setup_days_before_expiration(tool):
     setup.runImportStepFromProfile(profile, "plone.app.registry")
 
     logger.info("Setup days before expiration [DONE]")
+
+
+def rename_recover_to_retrieve(tool):
+    """Renames the user-facing term 'recover' to 'retrieve', which aligns with
+    ISO 17025 and ISO 15189 standard terminology for the process of taking
+    samples out of storage. Internal transition IDs and permission strings
+    remain unchanged for backwards compatibility.
+    """
+    logger.info("Recover --> Retrieve ...")
+    portal = tool.aq_inner.aq_parent
+
+    # Update the sample workflow (transition title/action)
+    setup_workflows(portal)
+
+    # Re-import the storage workflow definition (transition title/action)
+    setup = portal.portal_setup
+    setup.runImportStepFromProfile(profile, "workflow")
+
+    logger.info("Recover --> Retrieve [DONE]")

--- a/src/senaite/storage/upgrade/v02_07_000.zcml
+++ b/src/senaite/storage/upgrade/v02_07_000.zcml
@@ -3,6 +3,19 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="Rename 'Recover' to 'Retrieve' in workflow titles"
+      description="
+        Updates the user-facing workflow transition titles and action labels
+        from 'Recover' to 'Retrieve'. This aligns with ISO 17025 and
+        ISO 15189 standard terminology for the process of taking samples
+        out of storage. Internal transition IDs and permission strings
+        remain unchanged for backwards compatibility."
+      source="2709"
+      destination="2710"
+      handler=".v02_07_000.rename_recover_to_retrieve"
+      profile="senaite.storage:default"/>
+
+  <genericsetup:upgradeStep
       title="Add 'Days before expiration' setting"
       description="
         This setting stores the number of days before a sample's retention

--- a/src/senaite/storage/workflow/guards.py
+++ b/src/senaite/storage/workflow/guards.py
@@ -50,7 +50,7 @@ class GuardsAdapter(object):
         return not context.is_full()
 
     def guard_recover_samples(self, context):
-        """Guard for recover all samples from this container
+        """Guard for retrieving all samples from this container
         """
         if not IStorageSamplesContainer.providedBy(context):
             return False

--- a/src/senaite/storage/workflow/sample/events.py
+++ b/src/senaite/storage/workflow/sample/events.py
@@ -38,8 +38,9 @@ def is_store_primary_enabled():
 
 
 def is_recover_primary_enabled():
-    """Returns whether the transition 'recover' must be automatically triggered
-    for primary sample when all its partitions have been recovered
+    """Returns whether the 'recover' (retrieve) transition must be
+    automatically triggered for primary sample when all its partitions
+    have been retrieved
     """
     key = "{}.recover_primary".format(PRODUCT_NAME)
     return api.get_registry_record(key, default=True)
@@ -48,7 +49,7 @@ def is_recover_primary_enabled():
 def before_dispatch(sample):
     """Event triggered before "dispatch" transition takes place for a given sample
     """
-    # recover sample if the sample was stored
+    # retrieve sample if the sample was stored
     state = api.get_workflow_status_of(sample)
     if state == "stored":
         do_action_for(sample, "recover")
@@ -82,7 +83,7 @@ def after_store(sample):
 
 
 def after_recover(sample):
-    """Unassigns the sample from its storage container and "recover". It also
+    """Retrieves the sample from its storage container. Unassigns it and
     transitions the sample to its previous state before it was stored
     """
     # remove the sample from the container
@@ -103,7 +104,7 @@ def after_recover(sample):
     sample.reindexObject()
 
     if not is_recover_primary_enabled():
-        # Do not auto-recover the primary, if any
+        # Do not auto-retrieve the primary, if any
         return
 
     # If the sample is a partition, try to promote to the primary
@@ -111,7 +112,7 @@ def after_recover(sample):
     if not primary:
         return
 
-    # Recover primary sample if all its partitions have been recovered
+    # Retrieve primary sample if all its partitions have been retrieved
     parts = primary.getDescendants()
 
     # Partitions in some statuses won't be considered.

--- a/src/senaite/storage/workflow/samplescontainer/events.py
+++ b/src/senaite/storage/workflow/samplescontainer/events.py
@@ -19,7 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 def after_recover_samples(samples_container):
-    """Recovers all samples contained in this samples container
+    """Retrieves all samples contained in this samples container
     """
     for sample in samples_container.get_samples():
         samples_container.remove_object(sample)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Renames all user-facing occurrences of "recover" to "retrieve" to align with ISO 17025 and ISO 15189 standard terminology for the process of taking samples out of storage.

Internal transition IDs (e.g., `recover`, `recover_samples`) and permission strings (e.g., `senaite.storage: Transition: Recover Sample`) remain unchanged for backwards compatibility.

## Current behavior before PR

All user-facing text uses "recover"

## Desired behavior after PR is merged

All user-facing text uses "retrieve" instead, while internal IDs and permissions stay the same.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
