### PR TITLE
Fixed address unicode error when running igrate_storage_facilities_to_dx

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #71 Fix UnicodeDecodeError when running migrate_storage_facility_to_dx
 - #68 Require selection of retrieve reason when retrieving samples from storage
 - #67 Rename "Recover" transtion to "Retrieve" to align with ISO 17025/15189
 - #66 Add visual warning for samples approaching retention expiration

--- a/src/senaite/storage/upgrade/v02_07_000.py
+++ b/src/senaite/storage/upgrade/v02_07_000.py
@@ -145,6 +145,8 @@ def migrate_storage_facility_to_dx(src, destination):
 
     address = dict(src.getAddress())
     address["type"] = PHYSICAL_ADDRESS
+    for key in list(address.keys()):
+        address[key] = api.safe_unicode(address.get(key, u""))
     target.setAddress(address)
 
     cb = src.manage_copyObjects(ids=src.objectIds())


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.storage/issues/

## Current behavior before PR
Running the upgrade script 2700 renders the ff error
```
We’re sorry, but there seems to be an error…
UnicodeDecodeError
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.CMFPlone.controlpanel.browser.quickinstaller, line 666, in __call__
  Module Products.CMFPlone.controlpanel.browser.quickinstaller, line 399, in upgrade_product
  Module Products.GenericSetup.tool, line 1202, in upgradeProfile
  Module Products.GenericSetup.upgrade, line 185, in doStep
  Module senaite.storage.upgrade.v02_07_000, line 123, in migrate_storage_facilities_to_dx
  Module senaite.storage.upgrade.v02_07_000, line 185, in migrate_storage_facility_to_dx
  Module senaite.core.migration.migrator, line 131, in copy_id
  Module plone.folder.ordered, line 202, in manage_renameObject
  Module OFS.CopySupport, line 403, in manage_renameObject
  Module zope.event, line 33, in notify
  Module zope.component.event, line 27, in dispatch
  Module zope.component._api, line 134, in subscribers
  Module zope.interface.registry, line 448, in subscribers
  Module zope.interface.adapter, line 899, in subscribers
  Module zope.component.event, line 36, in objectEventNotify
  Module zope.component._api, line 134, in subscribers
  Module zope.interface.registry, line 448, in subscribers
  Module zope.interface.adapter, line 899, in subscribers
  Module plone.app.discussion.comment, line 309, in notify_content_object_moved
  Module Products.CMFPlone.CatalogTool, line 440, in searchResults
  Module Products.CMFCore.indexing, line 97, in processQueue
  Module Products.CMFCore.indexing, line 227, in process
  Module senaite.core.catalog.catalog_multiplex_processor, line 105, in reindex
  Module Products.CMFCore.CatalogTool, line 368, in _reindexObject
  Module Products.CMFPlone.CatalogTool, line 362, in catalog_object
  Module Products.ZCatalog.ZCatalog, line 508, in catalog_object
  Module Products.ZCatalog.Catalog, line 341, in catalogObject
  Module Products.ZCatalog.Catalog, line 292, in updateMetadata
  Module Products.ZCatalog.Catalog, line 427, in recordify
  Module senaite.storage.content.storage_facility, line 131, in Description
  Module string, line 207, in safe_substitute
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 0: ordinal not in range(128)
```
## Desired behavior after PR is merged
Upgrade script to run successfully

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
