### PR TITLE
Compatibility with core#2962 (Remove RegulatoryInspector)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #73 Compatibility with core#2962 (Remove RegulatoryInspector)
 - #71 Fix UnicodeDecodeError when running migrate_storage_facility_to_dx
 - #68 Require selection of retrieve reason when retrieving samples from storage
 - #67 Rename "Recover" transtion to "Retrieve" to align with ISO 17025/15189

--- a/src/senaite/storage/profiles/default/workflows/senaite_storage_folder_workflow/definition.xml
+++ b/src/senaite/storage/profiles/default/workflows/senaite_storage_folder_workflow/definition.xml
@@ -25,7 +25,6 @@
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
       <permission-role>Preserver</permission-role>
-      <permission-role>RegulatoryInspector</permission-role>
       <permission-role>Sampler</permission-role>
       <permission-role>SamplingCoordinator</permission-role>
       <permission-role>StorageManager</permission-role>
@@ -41,7 +40,6 @@
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
       <permission-role>Preserver</permission-role>
-      <permission-role>RegulatoryInspector</permission-role>
       <permission-role>Sampler</permission-role>
       <permission-role>SamplingCoordinator</permission-role>
       <permission-role>StorageManager</permission-role>
@@ -65,7 +63,6 @@
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
       <permission-role>Preserver</permission-role>
-      <permission-role>RegulatoryInspector</permission-role>
       <permission-role>Sampler</permission-role>
       <permission-role>SamplingCoordinator</permission-role>
       <permission-role>StorageManager</permission-role>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

> [!IMPORTANT]
> Requires:
> - https://github.com/senaite/senaite.core/pull/2962

This Pull Request makes this product compatible with https://github.com/senaite/senaite.core/pull/2962

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
