### PR TITLE
Use flat_listing for the stored and past-retention sample listings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #74 Use flat_listing for the stored and past-retention sample listings
 - #71 Fix UnicodeDecodeError when running migrate_storage_facility_to_dx
 - #68 Require selection of retrieve reason when retrieving samples from storage
 - #67 Rename "Recover" transtion to "Retrieve" to align with ISO 17025/15189

--- a/src/senaite/storage/adapters/listing.py
+++ b/src/senaite/storage/adapters/listing.py
@@ -98,6 +98,9 @@ ADD_REVIEW_STATES = (
             u"listing_samples_state_stored",
             default=u"Stored"
         ),
+        # flat pool: show every stored sample (partitions included) on its
+        # own row, without nesting them under their primary
+        "flat_listing": True,
         "contentFilter": {
             "review_state": ("stored",),
             "sort_on": "created",
@@ -112,6 +115,9 @@ ADD_REVIEW_STATES = (
             u"listing_samples_state_past_retention",
             default=u"Past Retention"
         ),
+        # flat pool: show every stored sample (partitions included) on its
+        # own row, without nesting them under their primary
+        "flat_listing": True,
         "contentFilter": {
             "review_state": ("stored",),
             "sort_on": "getStorageExpiryDate",
@@ -139,7 +145,6 @@ class AnalysisRequestsListingViewAdapter(object):
         self.listing = listing
         self.context = context
         self.installed = is_installed()
-        self.flat_listing = False
 
     @property
     def warning_days_before_expiration(self):
@@ -164,10 +169,10 @@ class AnalysisRequestsListingViewAdapter(object):
         # Additional custom transitions
         map(self.add_custom_transition, ADD_CUSTOM_TRANSITIONS)
 
-        # In "stored" status, display all samples in "flat style"
-        if self.is_stored_state():
-            self.flat_listing = True
-            self.listing.contentFilter.pop("isRootAncestor", None)
+        # The "stored" and "past_retention" review states are flagged as
+        # flat listings (see their `flat_listing` key), so senaite.core drops
+        # the root-ancestor restriction and renders every stored sample,
+        # partitions included, on its own row without nesting.
 
         # Update the contentFilter of the "past_retention" filter, so only
         # stored samples whose retention period has passed are displayed


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Companion to senaite/senaite.core#2976.

senaite.core #2976 changes how the samples listing handles partitions: instead of removing the root-ancestor restriction wholesale, it keeps partitions in the query and applies per-result orphan detection, so a partition nests under its primary whenever both are present in the same result set.

The `stored` and `past_retention` listings are flat pools: every stored sample, partitions included, must appear on its own row. With the new default a stored partition whose primary is also stored would be nested (and hidden) under that primary. This PR opts those listings into the flat behavior via the `flat_listing` review-state flag that senaite.core now honours.

## Current behavior before PR

- The `stored` state sets a `flat_listing` attribute on the listing adapter (which nothing reads) and pops `isRootAncestor` from the content filter directly.
- With senaite.core #2976 the samples listing also runs `hide_nested_partitions`, so a stored partition whose primary is also stored is nested/hidden under the primary instead of shown on its own.

## Desired behavior after PR is merged

- The `stored` and `past_retention` review states carry `"flat_listing": True`. senaite.core drops the root-ancestor restriction and skips the partition nesting/orphan-hiding for them, so every stored sample and partition is listed on its own row.
- The dead `flat_listing` adapter attribute and the manual `isRootAncestor` pop are removed; the flag drives the behavior instead.

> Requires senaite/senaite.core#2976 (the `flat_listing` handling it restores). Merge together.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
