### PR TITLE
Fix blank "Date stored" column in the samples listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #75 Fix blank "Date stored" column in the samples listing
 - #72 Add printable barcode stickers for storage location objects
 - #73 Compatibility with core#2962 (Remove RegulatoryInspector)
 - #74 Use flat_listing for the stored and past-retention sample listings

--- a/src/senaite/storage/monkeys/content/analysisrequest.py
+++ b/src/senaite/storage/monkeys/content/analysisrequest.py
@@ -27,8 +27,13 @@ from senaite.storage import check_installed
 @check_installed(None)
 def getDateStored(self):
     """Returns the date the sample was stored
+
+    Returned as a `DateTime` so it can be indexed by the `getDateStored`
+    DateIndex and localized by the samples listing. `getTransitionDate`
+    defaults to a pre-formatted string, which neither the index nor the
+    listing can consume, leaving the "Date stored" column blank.
     """
-    return wf.getTransitionDate(self, "store") or None
+    return wf.getTransitionDate(self, "store", return_as_datetime=True) or None
 
 
 @check_installed(None)

--- a/src/senaite/storage/profiles/default/metadata.xml
+++ b/src/senaite/storage/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>2712</version>
+  <version>2713</version>
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>
     <dependency>profile-senaite.lims:default</dependency>

--- a/src/senaite/storage/upgrade/v02_07_000.py
+++ b/src/senaite/storage/upgrade/v02_07_000.py
@@ -614,3 +614,27 @@ def rename_recover_to_retrieve(tool):
     setup.runImportStepFromProfile(profile, "workflow")
 
     logger.info("Recover --> Retrieve [DONE]")
+
+
+def reindex_date_stored(tool):
+    """Reindex 'getDateStored' for the samples already in storage
+
+    getDateStored now returns a DateTime instead of a pre-formatted string,
+    so the index and metadata column of samples already stored need to be
+    rebuilt for the "Date stored" column to show up.
+    """
+    logger.info("Reindex date stored ...")
+
+    cat = api.get_tool(SAMPLE_CATALOG)
+    brains = cat(review_state="stored")
+    total = len(brains)
+    for num, brain in enumerate(brains):
+        if num and num % 100 == 0:
+            logger.info("Processed objects: {0}/{1}".format(num, total))
+            transaction.savepoint()
+
+        obj = api.get_object(brain)
+        obj.reindexObject(idxs=["getDateStored"])
+        obj._p_deactivate()
+
+    logger.info("Reindex date stored [DONE]")

--- a/src/senaite/storage/upgrade/v02_07_000.zcml
+++ b/src/senaite/storage/upgrade/v02_07_000.zcml
@@ -3,6 +3,17 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="Reindex 'Date stored' for samples in storage"
+      description="
+        getDateStored now returns a DateTime instead of a pre-formatted
+        string, so the 'getDateStored' index and metadata of samples already
+        in storage are rebuilt for the 'Date stored' column to show up."
+      source="2712"
+      destination="2713"
+      handler=".v02_07_000.reindex_date_stored"
+      profile="senaite.storage:default"/>
+
+  <genericsetup:upgradeStep
       title="Add stickers preview action to storage location types"
       description="
         Adds a 'Stickers preview' object action to the storage facility,


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The "Date stored" column in the stored and past-retention samples listing is always blank, even for samples that were correctly transitioned into storage.

## Current behavior before PR

`getDateStored` returns the store date via `getTransitionDate(self, "store")`, which by default returns a pre-formatted, localized string. That value cannot be indexed by the `getDateStored` DateIndex, and the samples listing then localizes it a second time via `to_localized_time`, which fails on an already-formatted string. The store transition is recorded correctly, but the "Date stored" column ends up empty.

## Desired behavior after PR is merged

`getDateStored` returns the store date as a `DateTime` (`return_as_datetime=True`), so both the DateIndex and the listing can consume it and the column shows the storage date. An upgrade step reindexes `getDateStored` for the samples already in storage so existing data is corrected as well.

Notes on testing: code is flake8 clean; the reindex upgrade step mirrors the existing `getStorageExpiryDate` reindex in the same `2.7.0` cycle. Still worth a quick check on a running instance that the column populates after storing a sample and after running the upgrade step on pre-existing stored samples.

--
I confirm I have coded this according to [PEP8][1] and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html